### PR TITLE
RFC: Export Keyword for Values

### DIFF
--- a/docs/export-keyword.md
+++ b/docs/export-keyword.md
@@ -2,125 +2,162 @@
 
 ## Summary
 
-Allow users to export methods and values from their libraries through the use of the export keyword.
+Extend the `export` keyword to support values and functions.
 
 ## Motivation
 
-Users can export types from their libraries through the use of the export keyword.
+Today, it is possible to export a type from a module with the `export` keyword:
 
 ```luau
 export type Point = { x: number, y: number }
 ```
 
-Consumers of these libraries are able to access exported types by indexing the libraries identifier.
-
-```luau
-local Library = require("Library")
-local point : Library.Point = { x = 0, y = 0 }
-```
-
-Right now, this is the only use of the export keyword but it would be great if we let users export more with it to offer more utility and make exporting library methods and values easier.
+However, this mechanism is currently limited to types. Extending `export` to values and functions would provide a consistent way to expose a stable API from a module, while avoiding the extra boilerplate of returning a table.
 
 ## Design
 
 ### Syntax
-You can prefix any non-local declaration with the export keyword in the top level scope of a module. For values this looks like:
+
+Allow `export` in declarations anywhere `local` is allowed, but only at the top-level of a module. It may prefix a value, function, or type:
 
 ```luau
 export version = "5.1"
+
+export function init()
+	-- do a thing
+end
+
+export type Point = { x: number, y: number }
 ```
 
-While methods use:
+`export` for values is not permitted inside function bodies or other non–top-level scopes. Doing so results in a parse error.
+
+### Semantics
+
+#### Const By-Default
+
+Exported values and functions are implicitly [`const`](https://github.com/luau-lang/rfcs/pull/166). This means that exports must be initialized at the point of declaration and cannot be reassigned after initialization.
 
 ```luau
-export function init()
-  -- do a thing
+export foo = 5
+foo = 6 -- error: exported bindings are const
+```
+
+Without this, it would be possible to mutate the variable without changing to the exported table, leading to the following foot-gun:
+
+```luau
+export foo = 5
+
+export function increment()
+	foo += 1 -- 'foo' won't change in the exported table
 end
 ```
 
-### Behavior
+#### Export Table Construction
 
-When a value or method is prefixed with export, it is automatically added to a hidden export table which is frozen as soon as the module returns.
+Rather than populating an export table incrementally, the set of exported bindings is collected during parsing. When module execution completes, the module implicitly returns a frozen table containing the exported bindings.
 
-Take the following module:
+For example, the following module:
 
 ```luau
 export type Point = { x: number, y: number }
 
 export function distance(a: Point, b: Point)
-  local x, y = a.X - b.X, a.Y - b.Y
-  return math.sqrt(x * x + y * y)
+	local x, y = a.X - b.X, a.Y - b.Y
+	return math.sqrt(x * x + y * y)
 end
 ```
 
-This essentially becomes sugar for:
+Can be considered sugar for:
 
 ```luau
-local _EXT = {}
+export type Point = { x: number, y: number }
 
-type Point = { x: number, y: number }
-type _EXT.Point = Point -- note: this doesn't actually work today but one day it should
-
-local function distance(a: Point, b: Point)
-  local x, y = a.X - b.X, a.Y - b.Y
-  return math.sqrt(x * x + y * y)
+const function distance(a: Point, b: Point)
+	local x, y = a.X - b.X, a.Y - b.Y
+	return math.sqrt(x * x + y * y)
 end
-_EXT.distance = distance
 
-return table.freeze(_EXT)
+return table.freeze({
+	distance = distance,
+})
 ```
 
-If the user attempts to assign to an exported identifier then we would throw an error explaining that the interface cannot be changed once it has been exported.
+#### Export Shorthand
 
-### Nuances
-Due to the implementation, most things should "just-work". Here are some examples to consider:
+For convenience, we provide a shorthand form of `export` which will export an existing binding with the same name:
 
-#### Calling an Exported Function
-You can call an exported function as it's registered as a local before being added to the export table.
+```luau
+const foo = computeFoo()
+export foo
+```
+
+#### Order of Declarations and Mutual Dependencies
+
+As with `local` and `const` exports are evaluated in source order. Using the shorthand from above, mutually recursive or dependent functions can be declared before they are exported.
+
+```luau
+function a()
+	return b()
+end
+
+function b()
+	return 42
+end
+
+export a
+export b
+```
+
+Exporting before a binding is initialized is an error. Supporting hoisted exports or forward declarations is out of scope for this proposal and may be explored in a future RFC.
+
+#### Calling Exported Functions Internally
+
+Exported functions are still available within the module and can be called normally:
 
 ```luau
 export function distance(a: Point, b: Point)
-  local x, y = a.X - b.X, a.Y - b.Y
-  return math.sqrt(x * x + y * y)
+	return math.sqrt((a.X - b.X)^2 + (a.Y - b.Y)^2)
 end
 
 distance({0, 0}, {1, 1})
 ```
 
 #### Nested Tables
-You can export tables with additional values inside of them.
+
+Exporting a table exports the binding, not the contents of the table:
 
 ```luau
 export triangle = {}
 
 function triangle.draw()
-
+	-- ...
 end
 ```
 
-Something important to note here is that the nested table, `triangle` is not frozen.
+The `triangle` binding is immutable, but the table itself is mutable unless explicitly frozen.
 
 #### Returns
-Today, you can use the export keyword along with a return statement at the end of your module. If you use the export keyword with a value however we will throw an error if you also attempt to return.
+
+A module that uses `export` for values or functions may not also return a custom value. Attempting to do so is an error:
 
 ```luau
 export function distance(a: Point, b: Point)
-  local x, y = a.X - b.X, a.Y - b.Y
-  return math.sqrt(x * x + y * y)
+	return math.sqrt((a.X - b.X)^2)
 end
 
-return table.freeze {
-  distance = distance
-}
+return { distance = distance } -- error
 ```
 
+Type-only exports may continue to coexist with an explicit return value, as they do today.
+
 ## Drawbacks
-The keyword already exists for types so there's not much cost in us adding support to values. The main drawback is that it's another way to do module exports. We already have a way to do that, do we really need another?
+
+* Introduces another way to define module exports alongside explicit return tables.
+* Requires exported bindings to be immutable, which may require restructuring some existing patterns.
+* Extends the surface area of the `export` keyword beyond types.
 
 ## Alternatives
 
-### Do Nothing
-It's already possible to export values from modules using a return statement. We don't actually need to do this, it's more of a nice-to-have.
-
-### Automatically Export Globals
-Luau has a separate global scope for each module rather than a shared global scope across the entire program. We could automatically export any values that are stored in the global scope. This isn't backwards compatible though, we'd likely need a new import mechanism to resolve this.
+- Modules could implicitly export all top-level bindings. This is not backwards compatible, reduces explicitness, and complicates reasoning about module APIs.
+- Modules can already export values by returning tables explicitly. This proposal is a quality-of-life and consistency improvement but is not strictly necessary.

--- a/docs/export-keyword.md
+++ b/docs/export-keyword.md
@@ -18,7 +18,7 @@ However, this mechanism is currently limited to types. Extending `export` to val
 
 ### Syntax
 
-Allow `export` in declarations anywhere `local` is allowed, but only at the top-level of a module. It may prefix a value, function, or type:
+Allow `export` in declarations anywhere that defines a name (`local`s, `function`s, and `type`s), but only at the top-level of a module:
 
 ```luau
 export version = "5.1"
@@ -92,7 +92,7 @@ const foo = computeFoo()
 export foo
 ```
 
-If `foo` was declared as `local` instead of `const` then subequent uses of it here will be treates as if it were declared as `const`.
+If `foo` was declared as `local` instead of `const` then subsequent uses of it here will be treated as if it were declared as `const`.
 
 #### Order of Declarations and Mutual Dependencies
 

--- a/docs/export-keyword.md
+++ b/docs/export-keyword.md
@@ -100,7 +100,7 @@ end
 
 Something important to note here is that the nested table, `triangle` is not frozen.
 
-#### Multiple Returns
+#### Returns
 Today, you can use the export keyword along with a return statement at the end of your module. If you use the export keyword with a value however we will throw an error if you also attempt to return.
 
 ```luau

--- a/docs/export-keyword.md
+++ b/docs/export-keyword.md
@@ -92,6 +92,8 @@ const foo = computeFoo()
 export foo
 ```
 
+If `foo` was declared as `local` instead of `const` then subequent uses of it here will be treates as if it were declared as `const`.
+
 #### Order of Declarations and Mutual Dependencies
 
 As with `local` and `const` exports are evaluated in source order. Using the shorthand from above, mutually recursive or dependent functions can be declared before they are exported.

--- a/docs/export-keyword.md
+++ b/docs/export-keyword.md
@@ -1,0 +1,126 @@
+# Export Keyword
+
+## Summary
+
+Allow users to export methods and values from their libraries through the use of the export keyword.
+
+## Motivation
+
+Users can export types from their libraries through the use of the export keyword.
+
+```luau
+export type Point = { x: number, y: number }
+```
+
+Consumers of these libraries are able to access exported types by indexing the libraries identifier.
+
+```luau
+local Library = require("Library")
+local point : Library.Point = { x = 0, y = 0 }
+```
+
+Right now, this is the only use of the export keyword but it would be great if we let users export more with it to offer more utility and make exporting library methods and values easier.
+
+## Design
+
+### Syntax
+You can prefix any non-local declaration with the export keyword in the top level scope of a module. For values this looks like:
+
+```luau
+export version = "5.1"
+```
+
+While methods use:
+
+```luau
+export function init()
+  -- do a thing
+end
+```
+
+### Behavior
+
+When a value or method is prefixed with export, it is automatically added to a hidden export table which is frozen as soon as the module returns.
+
+Take the following module:
+
+```luau
+export type Point = { x: number, y: number }
+
+export function distance(a: Point, b: Point)
+  local x, y = a.X - b.X, a.Y - b.Y
+  return math.sqrt(x * x + y * y)
+end
+```
+
+This essentially becomes sugar for:
+
+```luau
+local _EXT = {}
+
+type Point = { x: number, y: number }
+type _EXT.Point = Point -- note: this doesn't actually work today but one day it should
+
+local function distance(a: Point, b: Point)
+  local x, y = a.X - b.X, a.Y - b.Y
+  return math.sqrt(x * x + y * y)
+end
+_EXT.distance = distance
+
+return table.freeze(_EXT)
+```
+
+If the user attempts to assign to an exported identifier then we would throw an error explaining that the interface cannot be changed once it has been exported.
+
+### Nuances
+Due to the implementation, most things should "just-work". Here are some examples to consider:
+
+#### Calling an Exported Function
+You can call an exported function as it's registered as a local before being added to the export table.
+
+```luau
+export function distance(a: Point, b: Point)
+  local x, y = a.X - b.X, a.Y - b.Y
+  return math.sqrt(x * x + y * y)
+end
+
+distance({0, 0}, {1, 1})
+```
+
+#### Nested Tables
+You can export tables with additional values inside of them.
+
+```luau
+export triangle = {}
+
+function triangle.draw()
+
+end
+```
+
+Something important to note here is that the nested table, `triangle` is not frozen.
+
+#### Multiple Returns
+Today, you can use the export keyword along with a return statement at the end of your module. If you use the export keyword with a value however we will throw an error if you also attempt to return.
+
+```luau
+export function distance(a: Point, b: Point)
+  local x, y = a.X - b.X, a.Y - b.Y
+  return math.sqrt(x * x + y * y)
+end
+
+return table.freeze {
+  distance = distance
+}
+```
+
+## Drawbacks
+The keyword already exists for types so there's not much cost in us adding support to values. The main drawback is that it's another way to do module exports. We already have a way to do that, do we really need another?
+
+## Alternatives
+
+### Do Nothing
+It's already possible to export values from modules using a return statement. We don't actually need to do this, it's more of a nice-to-have.
+
+### Automatically Export Globals
+Luau has a separate global scope for each module rather than a shared global scope across the entire program. We could automatically export any values that are stored in the global scope. This isn't backwards compatible though, we'd likely need a new import mechanism to resolve this.


### PR DESCRIPTION
Allow users to export methods and values from their libraries directly through the use of the export keyword.

[Rendered View](https://github.com/luau-lang/rfcs/blob/rfc-export-keyword/docs/export-keyword.md)