### PR TITLE
Renamed all instances of type operators to type functions

### DIFF
--- a/docs/index-type-operator.md
+++ b/docs/index-type-operator.md
@@ -1,8 +1,8 @@
-# `index` type operator
+# `index` type function
 
 ## Summary
 
-This RFC proposes the addition of one type operator, `index`, which can be used to look up a specific property of another type (like TypeScript's Indexed Access Type).
+This RFC proposes the addition of one type function, `index`, which can be used to look up a specific property of another type (like TypeScript's Indexed Access Type).
 
 ## Motivation
 
@@ -27,13 +27,13 @@ end
 type unionType = typeof(bob["age"]) | typeof(bob["name"]) | typeof(bob["alive"]) -- unionType = number | string | boolean
 ```
 
-This is a valid Luau program; however, in order to define the type of `Person["age"]` we had to first declare a variable `bob` and utilize the `typeof` type operator. This is quite cumbersome when developers want to typecheck using the type of `Person["age"]` without having to declare a variable first. Additionally, in order to define the union type of all the properties of `Person`, current Luau requires an explicit list of each property using `typeof`.
+This is a valid Luau program; however, in order to define the type of `Person["age"]` we had to first declare a variable `bob` and utilize the `typeof` type function. This is quite cumbersome when developers want to typecheck using the type of `Person["age"]` without having to declare a variable first. Additionally, in order to define the union type of all the properties of `Person`, current Luau requires an explicit list of each property using `typeof`.
 
-The expected outcome of the index type operator is that it will enhance developer experience and allow Luau developers to more easily develop well-typed programs.
+The expected outcome of the index type function is that it will enhance developer experience and allow Luau developers to more easily develop well-typed programs.
 
 ## Design
 
-The solution to this problem is a type operator, `index`, that can compute the type based on the static properties of `Person`. Formally, the `index` type operator will take in two arguments: the type to index (indexee) and the type to index it with (indexer). This would allow us to instead write the following code:
+The solution to this problem is a type function, `index`, that can compute the type based on the static properties of `Person`. Formally, the `index` type function will take in two arguments: the type to index (indexee) and the type to index it with (indexer). This would allow us to instead write the following code:
 ```luau
 type Person = {
   age: number,
@@ -63,7 +63,7 @@ type age = index<Person, key> -- Error message: Second argument to index<Person,
 ```
 Note: these errors will be part of the general type family reduction errors since `index` will be built into the type family system.
 
-The indexee may be a union type. In this case, the type operator will distribute the arguments to multiple type families:
+The indexee may be a union type. In this case, the type function will distribute the arguments to multiple type families:
 ```luau
 type Person2 = {
   age: string
@@ -86,15 +86,15 @@ type exampleTy2 = index<typeof(exampleClass2), "Foo"> -- exampleTy2 = number
 type exampleTy3 = index<typeof(exampleClass3), "Foo"> -- exampleTy3 = string
 ```
 
-One edge case to consider when using/designing this type operator is that `__index` only supports 100 nested `__index` metamethods until it gives up. In the case that a property is not found within the 100 recursive calls, this type operator will fail to reduce.
+One edge case to consider when using/designing this type function is that `__index` only supports 100 nested `__index` metamethods until it gives up. In the case that a property is not found within the 100 recursive calls, this type function will fail to reduce.
 
 Implementation is straight forward: the type of the indexee will be determined (table, class, etc) -> search through the properties of the indexee and reduce to the corresponding type of the indexer if it exists; otherwise, reduce to an error. 
 
 ## Drawbacks
 
-A drawback to this feature is the possible increase in the cost of maintenance. In the end, this RFC proposes adding another built-in type operators to the new type system. However, the addition of this feature may be worthwhile, as the `index` type operator is a useful type feature that:
+A drawback to this feature is the possible increase in the cost of maintenance. In the end, this RFC proposes adding another built-in type functions to the new type system. However, the addition of this feature may be worthwhile, as the `index` type function is a useful type feature that:
 1. Alleviates the need to manually keep types in sync
-2. Provides a powerful way to access the properties of an object and perform various operations on it with other type operators
+2. Provides a powerful way to access the properties of an object and perform various operations on it with other type functions
 3. Allows the community to write code with fewer errors and more safety
 
 ## Alternatives
@@ -122,7 +122,7 @@ Because there are conflicting types for `p` depending on the run time, it is saf
 
 FYI: exact table type indicates that the table has only the properties listed in its type, and inexact table type indicates that the table has at least the properties listed in its type.
 
-Later down the line, we can also consider adding syntactic sugar for this type operator. Instead of doing:
+Later down the line, we can also consider adding syntactic sugar for this type function. Instead of doing:
 ```luau
 type name = index<Person, "name">
 ```

--- a/docs/index-type-operator.md
+++ b/docs/index-type-operator.md
@@ -61,7 +61,7 @@ If the indexer is not a type,
 local key = "age"
 type age = index<Person, key> -- Error message: Second argument to index<Person,_> is not a valid index type; Unknown type 'key'
 ```
-Note: these errors will be part of the general type family reduction errors since `index` will be built into the type family system.
+Note: these errors will be part of the general type function reduction errors since `index` will be built into the type function system.
 
 The indexee may be a union type. In this case, the type function will distribute the arguments to multiple type families:
 ```luau

--- a/docs/keyof-type-operator.md
+++ b/docs/keyof-type-operator.md
@@ -1,8 +1,8 @@
-# `keyof` and `rawkeyof` type operators
+# `keyof` and `rawkeyof` type functions
 
 ## Summary
 
-This RFC proposes the addition of two type operators, `keyof` and `rawkeyof`,
+This RFC proposes the addition of two type functions, `keyof` and `rawkeyof`,
 which can be used to derive a type automatically for the keys of a table or
 class.
 
@@ -39,7 +39,7 @@ this situation.
 
 ## Design
 
-The solution to this problem is a type operator, `keyof`, that can compute the
+The solution to this problem is a type function, `keyof`, that can compute the
 type based on the type of `animals`. This would allow us to instead write this
 code as follows:
 
@@ -103,7 +103,7 @@ that are allowed by indexing operations on tables of that type.
 
 The main drawbacks of implementing this are that it requires some pretty
 powerful machinery to support properly. Fortunately, however, we've already
-built the general machinery to support type operators into the ongoing work on
+built the general machinery to support type functions into the ongoing work on
 the new type inference engine for Luau, and as such, there is little remaining
 drawback to implementing this. In fact, the implementation is already all done
 in the new type inference engine and amounts to less than 200 lines of code

--- a/docs/rawget-type-operator.md
+++ b/docs/rawget-type-operator.md
@@ -1,12 +1,12 @@
-# `rawget` type operator
+# `rawget` type function
 
 ## Summary
 
-This RFC proposes the addition of a new type operator, `rawget`, which can be used to look up a specific property of a table type *without* invoking the `__index` metamethod.
+This RFC proposes the addition of a new type function, `rawget`, which can be used to look up a specific property of a table type *without* invoking the `__index` metamethod.
 
 ## Motivation
 
-Currently, `rawget` is a built-in runtime operator in the language ([rawget in Luau Global functions](https://luau-lang.org/library#global-functions)) that is missing a corresponding type operator that captures its behavior. This RFC seeks to address this hole in the type system by providing a builtin type operator for `rawget` that will allow Luau developers to express more accurate types in their code:
+Currently, `rawget` is a built-in runtime operator in the language ([rawget in Luau Global functions](https://luau-lang.org/library#global-functions)) that is missing a corresponding type function that captures its behavior. This RFC seeks to address this hole in the type system by providing a builtin type function for `rawget` that will allow Luau developers to express more accurate types in their code:
 
 ```luau
 local prop: rawget<typeof(someExpr), "someProp"> = rawget(someExpr, "someProp")
@@ -14,7 +14,7 @@ local prop: rawget<typeof(someExpr), "someProp"> = rawget(someExpr, "someProp")
 
 ## Design
 
-The functionality of the `rawget` type operator behaves the same as its [runtime counterpart](https://luau-lang.org/library#global-functions). Namely, it provide a way to look up a specific property of a table type without invoking the `__index` metamethod. 
+The functionality of the `rawget` type function behaves the same as its [runtime counterpart](https://luau-lang.org/library#global-functions). Namely, it provide a way to look up a specific property of a table type without invoking the `__index` metamethod. 
  
 ```luau
 local var1 = {
@@ -28,7 +28,7 @@ local var3 = setmetatable({ property = 1 }, { __index = var1 })
 type doesExist = rawget<typeof(var3), "property"> -- doesExist = number
 ```
 
-Error messages would be consistent with those of the `index` type operator:
+Error messages would be consistent with those of the `index` type function:
 ```luau
 type doesntExist = rawget<typeof(var2), "property">  -- Error message: Property '"property"' does not exist on type 'var2'
 
@@ -36,16 +36,16 @@ local key = "property"
 type age = rawget<Person, key> -- Error message: Second argument to rawget<Person, _> is not a valid index type; Unknown type 'key'
 ```
 
-Note: `rawget` type operator does not work on class types because they do not have direct fields that can be looked up without invoking its metamethod.
+Note: `rawget` type function does not work on class types because they do not have direct fields that can be looked up without invoking its metamethod.
 
-The implementation effort for this type operator is very minimal. Since the `rawget` type operator functions similarly to the `index` type operator, we can reuse the functions already used to implement the `index` type operator.
+The implementation effort for this type function is very minimal. Since the `rawget` type function functions similarly to the `index` type function, we can reuse the functions already used to implement the `index` type function.
 
 ## Drawbacks
 
-There aren't appreciable drawbacks. One possible drawback is the increase in the size of the codebase, which may complicate maintenance. However, this is not expected to be a major drawback since the code for `index` type operators already exists. By reusing the code, it is even fair to say that there will be less than 50 lines of code needed to implement this type operator.
+There aren't appreciable drawbacks. One possible drawback is the increase in the size of the codebase, which may complicate maintenance. However, this is not expected to be a major drawback since the code for `index` type functions already exists. By reusing the code, it is even fair to say that there will be less than 50 lines of code needed to implement this type function.
 
-Another drawback can come from the extra knowledge a user may need in order to use this type operator. For example, users will need to know the inner workings of types and how different operations interact with them (for instance, how `index` interacts with metatables that have the `__index` metamethod). However, this additional complexity is manageable because the language already incorporates such complexities at the runtime level. Developers are already familiar with concepts like `rawget`, so this does not add much new complexity. 
+Another drawback can come from the extra knowledge a user may need in order to use this type function. For example, users will need to know the inner workings of types and how different operations interact with them (for instance, how `index` interacts with metatables that have the `__index` metamethod). However, this additional complexity is manageable because the language already incorporates such complexities at the runtime level. Developers are already familiar with concepts like `rawget`, so this does not add much new complexity. 
 
 ## Alternatives
 
-An alternative to the `rawget` type operator is to enable users to modify the behavior of the existing `index` type operator to control its recursive nature. While this approach offers flexibility, it requires additional design considerations and complicates both usage and implementation. However, the introduction of "user-defined type functions" is planned for the near future. This will allow users to create their own type operators, making this alternative design feasible for developers to implement.
+An alternative to the `rawget` type function is to enable users to modify the behavior of the existing `index` type function to control its recursive nature. While this approach offers flexibility, it requires additional design considerations and complicates both usage and implementation. However, the introduction of "user-defined type functions" is planned for the near future. This will allow users to create their own type functions, making this alternative design feasible for developers to implement.


### PR DESCRIPTION
We're moving towards consciously adopting the language of "type functions" consistently for this group of features as we prepare for users to get their hands on the new solver.