### PR TITLE
Update syntax-leading-bar-and-ampersand.md

### DIFF
--- a/docs/syntax-leading-bar-and-ampersand.md
+++ b/docs/syntax-leading-bar-and-ampersand.md
@@ -49,7 +49,7 @@ type MyOverloadedFunction = unknown
     & ((number) -> string)
 ```
 
-OCaml and TypeScript supports this same syntax:
+OCaml and TypeScript support this same syntax:
 
 ```ocaml
 type 'a tree =


### PR DESCRIPTION
Simple grammar fix. 'OCaml' and 'TypeScript' are two separate entities, yet the conjugation of 'supports' implies they are one entity.