### PR TITLE
fix index-type-operator RFC to align with runtime behavior

### DIFF
--- a/docs/index-type-operator.md
+++ b/docs/index-type-operator.md
@@ -78,9 +78,10 @@ type idxType3 = index<Person | Person2, "age"> -- idxType3 = number | string
 type idxType4 = index<Person | Person2, "alive" | "age"> -- Error message: Property '"age" | "alive"' does not exist on type 'Person | Person2'
 ```
 
-In the circumstance that the indexee's type is a class or table with an `__index` metamethod, the type should reflect
-the result of the expression `(tableValue & ~nil) | (__indexValue)` where `~` is the negation type symbol. This fits
-with Luau's runtime behavior of metatables, falling back to a value from __index if the value is nonpresent.
+In the circumstance that the indexee's type is a class or table with an `__index` metamethod, and the result from the
+main table is nilable, the type should reflect the result of the expression `(tableValue & ~nil) | (__indexValue)` where
+`~` is the negation type symbol. This fits with Luau's runtime behavior of metatables, falling back to a value from
+__index if the main value is nonpresent.
 ```luau
 local exampleClass = { Foo = "eight" }
 local exampleClass2 = setmetatable({ Foo = 8 }, { __index = exampleClass })

--- a/docs/index-type-operator.md
+++ b/docs/index-type-operator.md
@@ -90,7 +90,7 @@ local exampleClass4 = setmetatable({ Foo = ... :: number? }, { __index = example
 
 type exampleTy2 = index<typeof(exampleClass2), "Foo"> -- exampleTy2 = number
 type exampleTy3 = index<typeof(exampleClass3), "Foo"> -- exampleTy3 = string
-type exampleTy3 = index<typeof(exampleClass4), "Foo"> -- exampleTy4 = number | string
+type exampleTy4 = index<typeof(exampleClass4), "Foo"> -- exampleTy4 = number | string
 ```
 
 One edge case to consider when using/designing this type function is that `__index` only supports 100 nested `__index` metamethods until it gives up. In the case that a property is not found within the 100 recursive calls, this type function will fail to reduce.

--- a/docs/index-type-operator.md
+++ b/docs/index-type-operator.md
@@ -78,14 +78,18 @@ type idxType3 = index<Person | Person2, "age"> -- idxType3 = number | string
 type idxType4 = index<Person | Person2, "alive" | "age"> -- Error message: Property '"age" | "alive"' does not exist on type 'Person | Person2'
 ```
 
-In the circumstance that the indexee's type is a class or table with an `__index` metamethod, the `__index` metamethod will *only* be invoked if the indexer is not found within the current scope:
+In the circumstance that the indexee's type is a class or table with an `__index` metamethod, the type should reflect
+the result of the expression `(tableValue & ~nil) | (__indexValue)` where `~` is the negation type symbol. This fits
+with Luau's runtime behavior of metatables, falling back to a value from __index if the value is nonpresent.
 ```luau
 local exampleClass = { Foo = "eight" }
 local exampleClass2 = setmetatable({ Foo = 8 }, { __index = exampleClass })
 local exampleClass3 = setmetatable({ Bar = "nine" }, { __index = exampleClass })
+local exampleClass4 = setmetatable({ Foo = ... :: number? }, { __index = exampleClass })
 
 type exampleTy2 = index<typeof(exampleClass2), "Foo"> -- exampleTy2 = number
 type exampleTy3 = index<typeof(exampleClass3), "Foo"> -- exampleTy3 = string
+type exampleTy3 = index<typeof(exampleClass4), "Foo"> -- exampleTy4 = number | string
 ```
 
 One edge case to consider when using/designing this type function is that `__index` only supports 100 nested `__index` metamethods until it gives up. In the case that a property is not found within the 100 recursive calls, this type function will fail to reduce.


### PR DESCRIPTION
currently the RFC specifies this behavior:
> the `__index` metamethod will *only* be invoked if the indexer is not found within the current scope

this will be changed to:
> the type should reflect the result of the expression `(tableValue & ~nil) | (__indexValue)` where `~` is the negation type symbol.

this better represents the actual runtime behavior for metatables