### PR TITLE
RFC: Interpolated string function calls

### DIFF
--- a/docs/syntax-interpolated-string-function-calls.md
+++ b/docs/syntax-interpolated-string-function-calls.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Allow calling functions with interpolated string literals without parentheses, optionally followed by a context table literal argument. This enables domain-specific language patterns like structured logging where the template, interpolation values, and optional additional context are all passed to the function.
+Allow calling functions with interpolated string literals without parentheses. The call is desugared into a function call with three arguments: a format string with `%s` placeholders, a table of the evaluated interpolation values, and a table of the original expression source texts. This enables domain-specific language patterns like structured logging, SQL escaping, and HTML templating.
 
 ## Motivation
 
@@ -22,69 +22,79 @@ print `Hello {name}`  -- currently a parse error
 
 The [string interpolation RFC](https://github.com/luau-lang/rfcs/blob/master/docs/syntax-string-interpolation.md) noted this restriction was "likely temporary while we work through string interpolation DSLs."
 
-This proposal lifts that restriction and extends it further to support an optional trailing table literal, enabling powerful DSL patterns. The primary motivating use case is structured logging, where it's valuable to capture both the formatted message and the template with its interpolation values for machine processing:
+This proposal lifts that restriction with semantics that decompose the interpolated string into its constituent parts, passing them to the called function. This enables the function to process the template, values, and expression metadata however it sees fit, without needing to implement its own string parser.
+
+### Structured logging
+
+The primary motivating use case is structured logging, where it is valuable to capture both the formatted message template and its interpolation values for machine processing:
 
 ```luau
-local name = "Alice"
-local log = require("@rbx/logging")
+local a = 1
+local function double(x: number)
+  return x * 2
+end
 
--- Calls log:Info with three arguments:
---   "Hello Alice" (formatted string)
---   "Hello {name}" (template)
---   {name = "Alice"} (interpolation values)
-log:Info `Hello {name}`
-
--- Calls log:Info with four arguments, adding structured context:
---   "Hello Alice" (formatted string)
---   "Hello {name}" (template)
---   {name = "Alice"} (interpolation values)
---   {userId = 12345, region = "us-east"} (additional context)
-log:Info `Hello {name}`, {userId = 12345, region = "us-east"}
+-- Desugars to `log:Info("The double of %s is %s", {a, double(a)}, {"a", "double(a)"})`
+-- Note that the second argument evalutes to {1, 2} at runtime, but not at the desugaring step.
+log:Info `The double of {a} is {double(a)}`
 ```
 
-This pattern is common in structured logging, where preserving the template enables aggregating logs by message pattern while the interpolation values and context provide searchable structured data for platforms like Splunk, Datadog, or Elasticsearch.
+The template string enables aggregating logs by message pattern (e.g. grouping all "The double of %s is %s" messages), while the values and expression names provide searchable structured data for platforms like Splunk, Datadog, or Elasticsearch.
 
-Without this feature, there are two alternatives:
+Without this feature, developers must either manually construct all arguments (tedious and error-prone) or use a logging library that implements its own template parsing at runtime (duplicating language functionality).
 
-1. Manually construct all arguments:
+### SQL escaping
 
-   ```luau
-   log:Info(`Hello {name}`, "Hello {name}", {name = name}, {userId = 12345, region = "us-east"})
-   ```
+Interpolated string calls enable safe, ergonomic SQL query construction where the function can automatically escape interpolated values:
 
-   This is tedious, duplicates the `name` variable twice (and the template string once), and is easy to get wrong when refactoring.
+```luau
+local sqlite = require("luau_sqlite")
 
-2. Use a logging library that performs its own template parsing at runtime:
+local function takeUserInput(db: sqlite.DB, user: string, comment: string)
+  -- Auto-escape inputs to guard against SQL injection
+  db:Exec `INSERT INTO user_inputs (user, comment) VALUES ({user}, {comment})`
+  -- Desugars to: db:Exec("INSERT INTO user_inputs (user, comment) VALUES (%s, %s)", {user, comment}, {"user", "comment"})
+end
+```
 
-   ```luau
-   log:Info("Hello {name}", {name = name, userId = 12345, region = "us-east"})
-   ```
+### HTML templating
 
-   This doesn't require new syntax, but requires the logging library to implement its own string interpolation separate from the language's built-in interpolation. It also cannot benefit from compile-time optimizations or static analysis that language-level support would enable.
+Similarly, HTML renderers can automatically escape interpolated values to prevent XSS attacks:
+
+```luau
+local tmpl = require("luau_html_renderer")
+
+local function renderPage(r: tmpl.Renderer, userinput: string)
+  -- Automatic XSS protection through escaping
+  return tmpl.HTML `The user asked about {userinput}`
+  -- Desugars to: tmpl.HTML("The user asked about %s", {userinput}, {"userinput"})
+end
+```
 
 ## Design
 
 ### Grammar
 
-The grammar for function calls is extended to allow an interpolated string as the argument, optionally followed by a comma and a table literal:
+The grammar for function calls is extended to allow an interpolated string as the argument:
 
 ```
 functioncall ::= prefixexp args
-args ::= '(' [explist] ')' | tableconstructor | LiteralString | stringinterp [',' tableconstructor]
+args ::= '(' [explist] ')' | tableconstructor | LiteralString | stringinterp
 ```
-
-Note that the optional `, tableconstructor` is only valid following `stringinterp`, not following a regular `LiteralString` or standalone `tableconstructor`.
 
 ### Semantics
 
-When a function is called with an interpolated string literal in this style, the call receives multiple arguments derived from the interpolated string:
+When a function is called with an interpolated string literal in this style, the compiler desugars the call into a function call with three arguments:
 
-1. **Formatted string**: The fully interpolated result (what you would get from the expression today)
-2. **Template string**: The original template with placeholders intact, e.g. `"Hello {name}"`
-3. **Interpolation table**: A table mapping placeholder names to their values at call time, e.g. `{name = "Alice"}`
-4. **Context table** (optional): If a table literal follows the interpolated string, it is passed as a fourth argument
+1. **Format string**: The template with each `{expression}` replaced by `%s`, e.g. `"The double of %s is %s"`
+2. **Values table**: A sequential table of the interpolation values, e.g. `{a, double(a)}`
+3. **Expressions table**: A sequential table of the original expression source texts, e.g. `{"a", "double(a)"}`
 
-For method calls (`:` syntax), `self` is passed first as usual, followed by these arguments.
+The format string and expressions table are determined at compile time. The values table is evaluated at runtime.
+
+For method calls (`:` syntax), `self` is passed first as usual, followed by these three arguments.
+
+If the interpolated string contains no interpolation expressions, the call passes a single string argument (the literal string), identical to a regular string literal call.
 
 ### Examples
 
@@ -92,24 +102,48 @@ For method calls (`:` syntax), `self` is passed first as usual, followed by thes
 local id = 42
 local user = {name = "Alice"}
 
--- Basic usage: passes three arguments
+-- Simple identifier
 log:Info `Processing item {id}`
--- Desugars to: log:Info("Processing item 42", "Processing item {id}", {id = 42})
+-- Desugars to: log:Info("Processing item %s", {42}, {"id"})
 
--- With context table: passes four arguments
-log:Info `User {user.name} logged in`, {timestamp = os.time()}
--- Desugars to: log:Info("User Alice logged in", "User {user.name} logged in", {user = {name = "Alice"}}, {timestamp = 1234567890})
+-- Member expression
+log:Info `User {user.name} logged in`
+-- Desugars to: log:Info("User %s logged in", {"Alice"}, {"user.name"})
+
+-- Multiple expressions
+log:Info `{user.name} is processing item {id}`
+-- Desugars to: log:Info("%s is processing item %s", {"Alice", 42}, {"user.name", "id"})
 ```
+
+### No expression restrictions
+
+Unlike some alternative designs that use named keys for interpolated values, this design uses positional tables. This means **any expression valid in a regular interpolated string is also valid here**, including function and method calls:
+
+```luau
+-- Function calls are allowed
+log:Info `Result is {compute()}`
+-- Desugars to: log:Info("Result is %s", {compute()}, {"compute()"})
+
+-- Method calls are allowed
+log:Info `Name is {user:getName()}`
+-- Desugars to: log:Info("Name is %s", {user:getName()}, {"user:getName()"})
+
+-- Repeated expressions are fine (each is a separate positional entry)
+log:Info `{increment()} and then {increment()}`
+-- Desugars to: log:Info("%s and then %s", {increment(), increment()}, {"increment()", "increment()"})
+```
+
+Since values are stored positionally rather than keyed by expression text, there is no ambiguity when the same expression appears multiple times or when expressions have side effects.
 
 ### Behavior with variadic functions
 
-Functions that accept variadic arguments will receive all the desugared arguments. For example, Roblox's `print` concatenates its arguments with spaces:
+Functions that accept variadic arguments will receive the three desugared arguments. For example, Roblox's `print` concatenates its arguments with spaces:
 
 ```luau
 local name = "Alice"
 print `Hello {name}`
--- Desugars to: print("Hello Alice", "Hello {name}", {name = "Alice"})
--- Output: Hello Alice Hello {name} table: 0x...
+-- Desugars to: print("Hello %s", {"Alice"}, {"name"})
+-- Output: Hello %s table: 0x... table: 0x...
 ```
 
 This is likely not the desired output. Developers wanting simple string interpolation should use parentheses:
@@ -118,37 +152,7 @@ This is likely not the desired output. Developers wanting simple string interpol
 print(`Hello {name}`)  -- Output: Hello Alice
 ```
 
-The parentheses-free form is intended for functions specifically designed to receive the expanded arguments, such as structured logging APIs.
-
-### Handling of duplicate placeholder names
-
-If the same identifier appears multiple times in a template, it appears once in the interpolation table:
-
-```luau
-log:Info `{x} + {x} = {result}`
--- Interpolation table is {x = 10, result = 20}, not {x = 10, x = 10, result = 20}
-```
-
-### Interpolation table keys for member expressions
-
-When a placeholder contains a member expression like `{user.name}`, the interpolation table uses nested tables mirroring the access path:
-
-```luau
-log:Info `{user.name} is {user.age} years old`
--- Interpolation table is {user = {name = "Alice", age = 30}}
-```
-
-This approach is more ergonomic for consuming code, which can use natural table access like `context.user.name`, and is more idiomatic to Lua/Luau's table-centric design.
-
-When multiple member expressions share a common root, their values are merged into a single nested structure. If a simple identifier `{user}` and a member expression `{user.name}` both appear, the simple identifier provides the full object, which already contains the nested values.
-
-An alternative design would use flat string keys:
-
-```luau
--- Alternative (not proposed): {["user.name"] = "Alice", ["user.age"] = 30}
-```
-
-This would be simpler to implement (no merging logic required) but less ergonomic, requiring consuming code to use string keys like `context["user.name"]`.
+The parentheses-free form is intended for functions specifically designed to receive the expanded arguments.
 
 ### Interaction with existing syntax
 
@@ -160,128 +164,102 @@ This feature does not change the behavior of:
 
 The new behavior only applies to calls without parentheses using interpolated strings.
 
-### Expression restrictions in templates
+### Passing additional context via currying
 
-When used in this calling style, the interpolated expressions within the template may not contain function or method calls:
-
-```luau
--- Valid: simple identifiers
-log:Info `Hello {name}`
-
--- Valid: member expressions
-log:Info `User {user.name} logged in`
-
--- Valid: arithmetic and other operators
-log:Info `Sum is {a + b}`
--- Desugars to: log:Info("Sum is 30", "Sum is {a + b}", {a = 10, b = 20})
-
--- Valid: other expressions
-log:Info `Count is {#items}`     -- {items = {...}}
-log:Info `Active: {not disabled}` -- {disabled = false}
-
--- Invalid: function calls
-log:Info `Result is {compute()}`  -- parse error
-
--- Invalid: method calls
-log:Info `Name is {user:getName()}`  -- parse error
-```
-
-Function and method calls are restricted because the same call expression can appear multiple times and return different values:
+Some use cases (e.g. structured logging) benefit from passing additional context alongside the interpolated string. Rather than introducing special syntax for an extra argument, this can be achieved through currying (a function that returns a function):
 
 ```luau
-log:Info `{increment()} and then {increment()}`
--- Formatted: "1 and then 2"
--- Template: "{increment()} and then {increment()}"
--- Context: ??? (can't use "increment()" as key twice with different values)
+-- log accepts the desugared interpolated string arguments and returns
+-- a function that accepts additional context
+function log(fmt, vals, exprs)
+  return function(context)
+    -- Reconstruct the formatted message
+    local message = string.format(fmt, table.unpack(vals))
+    -- Reconstruct a human-readable template using the expression names
+    local wrapped = table.create(#exprs)
+    for i, expr in exprs do
+      wrapped[i] = "{" .. expr .. "}"
+    end
+    local template = string.format(fmt, table.unpack(wrapped))
+    -- template is now "Hello {name}" -- the original template string.
+    emit(message, template, vals, exprs, context)
+  end
+end
+
+-- No parentheses anywhere -- log is called with the desugared
+-- interpolated string and returns a function, which is then called
+-- with the context table
+log `Hello {name}` {userId = 12345, region = "us-east"}
+
+-- Desugars to: log("Hello %s", {"Alice"}, {"name"})({userId = 12345, region = "us-east"})
 ```
 
-For all other expressions, the compiler extracts the referenced identifiers and includes them in the interpolation table. Identifiers have stable values within a single expression, so duplicates are not a problem.
+This approach requires no special grammar support. It is a natural composition of a parentheses-free interpolated string call (which returns a function) and a parentheses-free table literal call on that returned function.
 
-For function calls, use a local variable or the traditional parenthesized call syntax:
+### Bridging to existing functions with a `Message` type
+
+A `Message` wrapper type can bridge the gap between this calling convention and existing functions like `print` or `warn` that expect string arguments:
 
 ```luau
-local result = compute()
-log:Info `Result is {result}`  -- Valid: use a local variable
+local Message = {}
+Message.__index = Message
 
--- Or use parentheses for full flexibility
-log:Info("Result is " .. tostring(compute()))
+function Message.new(fmt, vals, exprs)
+  return setmetatable({
+    fmt = fmt,
+    values = vals,
+    expressions = exprs,
+  }, Message)
+end
+
+function Message:__tostring()
+  return string.format(self.fmt, table.unpack(self.values))
+end
 ```
 
-#### Potential future extension
-
-A future version could allow function calls by using indexed keys to distinguish multiple calls to the same expression:
+Because `Message` defines `__tostring`, existing functions that convert arguments to strings will produce the expected formatted output:
 
 ```luau
-log:Info `{increment()} and then {increment()}`
--- Could produce: {["increment()#1"] = 1, ["increment()#2"] = 2}
+-- Message.new receives the desugared arguments and returns a Message object
+-- print() calls tostring on it, producing "Hello Alice"
+print(Message.new `Hello {name}`)
+
+-- warn works the same way
+warn(Message.new `User {user.name} failed to log in`)
 ```
 
-This would also capture any identifiers referenced in the call arguments:
+Structured logging APIs can also inspect the Message's fields directly:
 
 ```luau
-log:Info `{compute(x)} and {compute(x)}`
--- Could produce: {x = 10, ["compute(x)#1"] = 42, ["compute(x)#2"] = 43}
+function structured_log(msg: Message)
+  emit(tostring(msg), msg.fmt, msg.values, msg.expressions)
+end
 ```
 
-However, this approach has a complication: function calls can mutate values, affecting subsequent expressions in the template:
-
-```luau
-log:Info `{x} {mutate(x)} {x}`
--- First {x} sees original value
--- mutate(x) changes x
--- Third {x} sees mutated value
--- But context only captures x once—which value?
-```
-
-This affects all identifiers, not just function call results. To handle this correctly, the indexed approach would need to apply to every expression in the template, not just function calls:
-
-```luau
-log:Info `{x} {mutate(x)} {x}`
--- Could produce: {
---   ["x#1"] = {value = 1},
---   ["mutate(x)#2"] = {result = nil, args = {x = {value = 1}}},
---   ["x#3"] = {value = 2}
--- }
-```
-
-This adds significant complexity. An alternative would be to document that the context captures values at an unspecified point during evaluation, and that templates with side effects may produce inconsistent results. This is left for future consideration.
+While not part of this proposal, this pattern also opens the door for existing functions to be updated to special-case a single `Message` argument, extracting structured data for telemetry while preserving their current behavior for all other callers.
 
 ## Drawbacks
 
 ### Increased complexity in the grammar
 
-Adding optional trailing arguments after interpolated strings adds complexity to the parser. However, the grammar remains unambiguous since the comma can only appear in this context.
-
-### Use-case-specific syntax
-
-The optional trailing context table argument is motivated primarily by structured logging, where additional metadata beyond the interpolated values is useful. In a pure language context, this extra argument may seem overly specific to one use case. However, the context table is optional, and the core feature (passing template and interpolation values to functions) is broadly useful for DSL patterns beyond logging.
+Adding interpolated strings as a parentheses-free call argument adds complexity to the parser. However, the grammar change is minimal and unambiguous.
 
 ### Learning curve
 
 Developers need to understand that interpolated string calls without parentheses behave differently from parenthesized calls. This could be confusing:
 
 ```luau
-log:Info `Hello {name}`        -- passes 3 arguments
-log:Info(`Hello {name}`)       -- passes 1 argument
+log:Info `Hello {name}`        -- passes 3 arguments (format, values, expressions)
+log:Info(`Hello {name}`)       -- passes 1 argument (formatted string)
 ```
 
 This distinction is intentional and valuable for DSL use cases, but documentation will need to clearly explain the difference.
 
-### Roblox built-in logging functions
+### Surprising behavior with existing functions
 
-In the Roblox engine, `print`, `warn`, and `error` have non-standard behavior: calls to them are treated as logging calls and feed into log telemetry. These functions handle arguments differently:
+Existing functions that are not designed for this calling convention will receive unexpected arguments if called without parentheses. For example, in Roblox, `print` and `warn` accept variadic arguments and would print the format string, values table, and expressions table alongside each other rather than producing a formatted message.
 
-- `print`: Accepts any number of arguments and prints their values (without calling `tostring`, though `__tostring` metamethods fire for tables)
-- `warn`: Accepts any number of arguments, converts them to strings, and joins them with spaces, outputting as a yellow warning with timestamp
-- `error`: Expects a single message argument and terminates execution
-
-For `print` and `warn`, parentheses-free interpolated string calls would produce confusing output since the template string and interpolation table would be printed alongside the formatted message. For `error`, the first argument is still the formatted message, so it would function correctly; the extra arguments would simply be ignored.
-
-Roblox could update these functions to leverage the extra arguments for structured log telemetry. Alternatively, a new structured logging library could be designed from the start to accept parentheses-free interpolated string calls, while developers continue using parenthesized calls for the legacy functions.
-
-### Restriction on function calls
-
-The restriction on function and method calls may frustrate developers who want to inline computed values. It also introduces inconsistency: regular string interpolation allows `{compute()}`, but the parentheses-free calling form does not. However, this restriction avoids the complexity of handling duplicate call expressions that return different values (e.g., `{increment()} and {increment()}` returning 1 and 2). A potential future extension using indexed keys is described in the Design section.
+Functions designed for parentheses-free interpolated string calls would need to be written (or updated) to accept the three-argument format. Developers should continue using parenthesized calls for existing functions, or use a pattern such as the `Message` wrapper type described in the Design section to bridge the gap.
 
 ## Alternatives
 
@@ -294,13 +272,47 @@ tag`Hello ${name}, you have ${count} messages`;
 // Calls: tag(["Hello ", ", you have ", " messages"], name, count)
 ```
 
-This was considered but rejected because:
+A Luau adaptation would pass two tables, string parts and values:
 
-1. It doesn't provide the template string directly, requiring reconstruction
-2. It doesn't provide a table mapping names to values
-3. The array-based API is less natural for Luau's table-centric design
+```luau
+tag `Hello {name}, you have {count} messages`
+-- Would call: tag({"Hello ", ", you have ", " messages"}, {name, count})
+```
+
+This was considered and the proposed design shares the same spirit: decomposing the interpolated string into parts that don't require the consumer to parse Luau expressions. The proposed design differs in using a format string with `%s` placeholders instead of a string parts array, and in providing an additional expressions table with the source text of each interpolated expression. The format string approach:
+
+1. Provides a single template string usable as a log aggregation key or cache key
+2. Is more familiar to Luau developers accustomed to `string.format`-style patterns
+3. Includes expression metadata (source text) useful for debugging and structured logging
+
+### Interpolation table with named keys
+
+An earlier version of this RFC proposed passing a table mapping expression names to their values:
+
+```luau
+log:Info `Hello {name}`
+-- Would pass: log:Info("Hello Alice", "Hello {name}", {name = "Alice"})
+```
+
+This was rejected because:
+
+1. It requires consumers to parse the `{...}` syntax in the template string to reconstruct the formatted output
+2. Complex expressions like `{a + b}` or `{user.name}` create awkward or ambiguous table keys
+3. Function and method calls must be restricted because repeated calls (e.g. `{increment()}` appearing twice) can produce different values for the same key
+4. Metamethods on property access can cause the same issues as function calls, as noted by reviewers
+
+The positional values table avoids all of these problems.
+
+### Extra context argument in grammar
+
+An earlier version proposed allowing an optional trailing table literal after the interpolated string:
+
+```luau
+log:Info `Hello {name}`, {userId = 12345}
+```
+
+This was rejected because it adds ambiguity to the grammar and is overly specific to the logging use case. The currying pattern described in the Design section provides equivalent functionality without grammar changes.
 
 ## References
 
 - [String interpolation RFC](https://github.com/luau-lang/rfcs/blob/master/docs/syntax-string-interpolation.md) - The original RFC that introduced interpolated strings and noted the temporary restriction
-- [API-1080](https://roblox.atlassian.net/browse/API-1080) - Structured logging APIs proposal that motivated this RFC

--- a/docs/syntax-interpolated-string-function-calls.md
+++ b/docs/syntax-interpolated-string-function-calls.md
@@ -1,0 +1,306 @@
+# Interpolated string function calls
+
+## Summary
+
+Allow calling functions with interpolated string literals without parentheses, optionally followed by a context table literal argument. This enables domain-specific language patterns like structured logging where the template, interpolation values, and optional additional context are all passed to the function.
+
+## Motivation
+
+Luau currently supports function calls without parentheses for string literals and table literals:
+
+```luau
+print "hello"        -- equivalent to print("hello")
+print { 1, 2, 3 }    -- equivalent to print({1, 2, 3})
+```
+
+When string interpolation was introduced, this calling style was explicitly prohibited for interpolated strings:
+
+```luau
+local name = "world"
+print `Hello {name}`  -- currently a parse error
+```
+
+The [string interpolation RFC](https://github.com/luau-lang/rfcs/blob/master/docs/syntax-string-interpolation.md) noted this restriction was "likely temporary while we work through string interpolation DSLs."
+
+This proposal lifts that restriction and extends it further to support an optional trailing table literal, enabling powerful DSL patterns. The primary motivating use case is structured logging, where it's valuable to capture both the formatted message and the template with its interpolation values for machine processing:
+
+```luau
+local name = "Alice"
+local log = require("@rbx/logging")
+
+-- Calls log:Info with three arguments:
+--   "Hello Alice" (formatted string)
+--   "Hello {name}" (template)
+--   {name = "Alice"} (interpolation values)
+log:Info `Hello {name}`
+
+-- Calls log:Info with four arguments, adding structured context:
+--   "Hello Alice" (formatted string)
+--   "Hello {name}" (template)
+--   {name = "Alice"} (interpolation values)
+--   {userId = 12345, region = "us-east"} (additional context)
+log:Info `Hello {name}`, {userId = 12345, region = "us-east"}
+```
+
+This pattern is common in structured logging, where preserving the template enables aggregating logs by message pattern while the interpolation values and context provide searchable structured data for platforms like Splunk, Datadog, or Elasticsearch.
+
+Without this feature, there are two alternatives:
+
+1. Manually construct all arguments:
+
+   ```luau
+   log:Info(`Hello {name}`, "Hello {name}", {name = name}, {userId = 12345, region = "us-east"})
+   ```
+
+   This is tedious, duplicates the `name` variable twice (and the template string once), and is easy to get wrong when refactoring.
+
+2. Use a logging library that performs its own template parsing at runtime:
+
+   ```luau
+   log:Info("Hello {name}", {name = name, userId = 12345, region = "us-east"})
+   ```
+
+   This doesn't require new syntax, but requires the logging library to implement its own string interpolation separate from the language's built-in interpolation. It also cannot benefit from compile-time optimizations or static analysis that language-level support would enable.
+
+## Design
+
+### Grammar
+
+The grammar for function calls is extended to allow an interpolated string as the argument, optionally followed by a comma and a table literal:
+
+```
+functioncall ::= prefixexp args
+args ::= '(' [explist] ')' | tableconstructor | LiteralString | stringinterp [',' tableconstructor]
+```
+
+Note that the optional `, tableconstructor` is only valid following `stringinterp`, not following a regular `LiteralString` or standalone `tableconstructor`.
+
+### Semantics
+
+When a function is called with an interpolated string literal in this style, the call receives multiple arguments derived from the interpolated string:
+
+1. **Formatted string**: The fully interpolated result (what you would get from the expression today)
+2. **Template string**: The original template with placeholders intact, e.g. `"Hello {name}"`
+3. **Interpolation table**: A table mapping placeholder names to their values at call time, e.g. `{name = "Alice"}`
+4. **Context table** (optional): If a table literal follows the interpolated string, it is passed as a fourth argument
+
+For method calls (`:` syntax), `self` is passed first as usual, followed by these arguments.
+
+### Examples
+
+```luau
+local id = 42
+local user = {name = "Alice"}
+
+-- Basic usage: passes three arguments
+log:Info `Processing item {id}`
+-- Desugars to: log:Info("Processing item 42", "Processing item {id}", {id = 42})
+
+-- With context table: passes four arguments
+log:Info `User {user.name} logged in`, {timestamp = os.time()}
+-- Desugars to: log:Info("User Alice logged in", "User {user.name} logged in", {user = {name = "Alice"}}, {timestamp = 1234567890})
+```
+
+### Behavior with variadic functions
+
+Functions that accept variadic arguments will receive all the desugared arguments. For example, Roblox's `print` concatenates its arguments with spaces:
+
+```luau
+local name = "Alice"
+print `Hello {name}`
+-- Desugars to: print("Hello Alice", "Hello {name}", {name = "Alice"})
+-- Output: Hello Alice Hello {name} table: 0x...
+```
+
+This is likely not the desired output. Developers wanting simple string interpolation should use parentheses:
+
+```luau
+print(`Hello {name}`)  -- Output: Hello Alice
+```
+
+The parentheses-free form is intended for functions specifically designed to receive the expanded arguments, such as structured logging APIs.
+
+### Handling of duplicate placeholder names
+
+If the same identifier appears multiple times in a template, it appears once in the interpolation table:
+
+```luau
+log:Info `{x} + {x} = {result}`
+-- Interpolation table is {x = 10, result = 20}, not {x = 10, x = 10, result = 20}
+```
+
+### Interpolation table keys for member expressions
+
+When a placeholder contains a member expression like `{user.name}`, the interpolation table uses nested tables mirroring the access path:
+
+```luau
+log:Info `{user.name} is {user.age} years old`
+-- Interpolation table is {user = {name = "Alice", age = 30}}
+```
+
+This approach is more ergonomic for consuming code, which can use natural table access like `context.user.name`, and is more idiomatic to Lua/Luau's table-centric design.
+
+When multiple member expressions share a common root, their values are merged into a single nested structure. If a simple identifier `{user}` and a member expression `{user.name}` both appear, the simple identifier provides the full object, which already contains the nested values.
+
+An alternative design would use flat string keys:
+
+```luau
+-- Alternative (not proposed): {["user.name"] = "Alice", ["user.age"] = 30}
+```
+
+This would be simpler to implement (no merging logic required) but less ergonomic, requiring consuming code to use string keys like `context["user.name"]`.
+
+### Interaction with existing syntax
+
+This feature does not change the behavior of:
+
+- Regular string literals: `print "hello"` continues to pass a single string argument
+- Table literals: `print {1, 2, 3}` continues to pass a single table argument
+- Parenthesized calls: `print(`hello {name}`)` continues to pass a single formatted string
+
+The new behavior only applies to calls without parentheses using interpolated strings.
+
+### Expression restrictions in templates
+
+When used in this calling style, the interpolated expressions within the template may not contain function or method calls:
+
+```luau
+-- Valid: simple identifiers
+log:Info `Hello {name}`
+
+-- Valid: member expressions
+log:Info `User {user.name} logged in`
+
+-- Valid: arithmetic and other operators
+log:Info `Sum is {a + b}`
+-- Desugars to: log:Info("Sum is 30", "Sum is {a + b}", {a = 10, b = 20})
+
+-- Valid: other expressions
+log:Info `Count is {#items}`     -- {items = {...}}
+log:Info `Active: {not disabled}` -- {disabled = false}
+
+-- Invalid: function calls
+log:Info `Result is {compute()}`  -- parse error
+
+-- Invalid: method calls
+log:Info `Name is {user:getName()}`  -- parse error
+```
+
+Function and method calls are restricted because the same call expression can appear multiple times and return different values:
+
+```luau
+log:Info `{increment()} and then {increment()}`
+-- Formatted: "1 and then 2"
+-- Template: "{increment()} and then {increment()}"
+-- Context: ??? (can't use "increment()" as key twice with different values)
+```
+
+For all other expressions, the compiler extracts the referenced identifiers and includes them in the interpolation table. Identifiers have stable values within a single expression, so duplicates are not a problem.
+
+For function calls, use a local variable or the traditional parenthesized call syntax:
+
+```luau
+local result = compute()
+log:Info `Result is {result}`  -- Valid: use a local variable
+
+-- Or use parentheses for full flexibility
+log:Info("Result is " .. tostring(compute()))
+```
+
+#### Potential future extension
+
+A future version could allow function calls by using indexed keys to distinguish multiple calls to the same expression:
+
+```luau
+log:Info `{increment()} and then {increment()}`
+-- Could produce: {["increment()#1"] = 1, ["increment()#2"] = 2}
+```
+
+This would also capture any identifiers referenced in the call arguments:
+
+```luau
+log:Info `{compute(x)} and {compute(x)}`
+-- Could produce: {x = 10, ["compute(x)#1"] = 42, ["compute(x)#2"] = 43}
+```
+
+However, this approach has a complication: function calls can mutate values, affecting subsequent expressions in the template:
+
+```luau
+log:Info `{x} {mutate(x)} {x}`
+-- First {x} sees original value
+-- mutate(x) changes x
+-- Third {x} sees mutated value
+-- But context only captures x once—which value?
+```
+
+This affects all identifiers, not just function call results. To handle this correctly, the indexed approach would need to apply to every expression in the template, not just function calls:
+
+```luau
+log:Info `{x} {mutate(x)} {x}`
+-- Could produce: {
+--   ["x#1"] = {value = 1},
+--   ["mutate(x)#2"] = {result = nil, args = {x = {value = 1}}},
+--   ["x#3"] = {value = 2}
+-- }
+```
+
+This adds significant complexity. An alternative would be to document that the context captures values at an unspecified point during evaluation, and that templates with side effects may produce inconsistent results. This is left for future consideration.
+
+## Drawbacks
+
+### Increased complexity in the grammar
+
+Adding optional trailing arguments after interpolated strings adds complexity to the parser. However, the grammar remains unambiguous since the comma can only appear in this context.
+
+### Use-case-specific syntax
+
+The optional trailing context table argument is motivated primarily by structured logging, where additional metadata beyond the interpolated values is useful. In a pure language context, this extra argument may seem overly specific to one use case. However, the context table is optional, and the core feature (passing template and interpolation values to functions) is broadly useful for DSL patterns beyond logging.
+
+### Learning curve
+
+Developers need to understand that interpolated string calls without parentheses behave differently from parenthesized calls. This could be confusing:
+
+```luau
+log:Info `Hello {name}`        -- passes 3 arguments
+log:Info(`Hello {name}`)       -- passes 1 argument
+```
+
+This distinction is intentional and valuable for DSL use cases, but documentation will need to clearly explain the difference.
+
+### Roblox built-in logging functions
+
+In the Roblox engine, `print`, `warn`, and `error` have non-standard behavior: calls to them are treated as logging calls and feed into log telemetry. These functions handle arguments differently:
+
+- `print`: Accepts any number of arguments and prints their values (without calling `tostring`, though `__tostring` metamethods fire for tables)
+- `warn`: Accepts any number of arguments, converts them to strings, and joins them with spaces, outputting as a yellow warning with timestamp
+- `error`: Expects a single message argument and terminates execution
+
+For `print` and `warn`, parentheses-free interpolated string calls would produce confusing output since the template string and interpolation table would be printed alongside the formatted message. For `error`, the first argument is still the formatted message, so it would function correctly; the extra arguments would simply be ignored.
+
+Roblox could update these functions to leverage the extra arguments for structured log telemetry. Alternatively, a new structured logging library could be designed from the start to accept parentheses-free interpolated string calls, while developers continue using parenthesized calls for the legacy functions.
+
+### Restriction on function calls
+
+The restriction on function and method calls may frustrate developers who want to inline computed values. It also introduces inconsistency: regular string interpolation allows `{compute()}`, but the parentheses-free calling form does not. However, this restriction avoids the complexity of handling duplicate call expressions that return different values (e.g., `{increment()} and {increment()}` returning 1 and 2). A potential future extension using indexed keys is described in the Design section.
+
+## Alternatives
+
+### Tagged interpolated strings (JavaScript-style)
+
+JavaScript's tagged template literals pass an array of string parts and the interpolated values as separate arguments:
+
+```javascript
+tag`Hello ${name}, you have ${count} messages`;
+// Calls: tag(["Hello ", ", you have ", " messages"], name, count)
+```
+
+This was considered but rejected because:
+
+1. It doesn't provide the template string directly, requiring reconstruction
+2. It doesn't provide a table mapping names to values
+3. The array-based API is less natural for Luau's table-centric design
+
+## References
+
+- [String interpolation RFC](https://github.com/luau-lang/rfcs/blob/master/docs/syntax-string-interpolation.md) - The original RFC that introduced interpolated strings and noted the temporary restriction
+- [API-1080](https://roblox.atlassian.net/browse/API-1080) - Structured logging APIs proposal that motivated this RFC

--- a/docs/syntax-interpolated-string-function-calls.md
+++ b/docs/syntax-interpolated-string-function-calls.md
@@ -92,6 +92,19 @@ When a function is called with an interpolated string literal in this style, the
 
 The format string and expressions table are determined at compile time. The values table is evaluated at runtime.
 
+Each entry in the expressions table is the verbatim source text between the `{` and `}` delimiters, with leading and trailing whitespace trimmed. Quoting style, internal spacing, and other formatting are preserved as written:
+
+```luau
+log `{  user.name  }`
+-- Expressions table: {"user.name"} (leading/trailing whitespace trimmed)
+
+log `{"Alice"}`
+-- Expressions table: {"\"Alice\""} (source text preserved, including quotes)
+
+log `{ { ["foo"] = "bar" } }`
+-- Expressions table: {"{ [\"foo\"] = \"bar\" }"} (trimmed, but internal formatting preserved)
+```
+
 For method calls (`:` syntax), `self` is passed first as usual, followed by these three arguments.
 
 If the interpolated string contains no interpolation expressions, the call passes a single string argument (the literal string), identical to a regular string literal call.

--- a/docs/syntax-interpolated-string-function-calls.md
+++ b/docs/syntax-interpolated-string-function-calls.md
@@ -150,7 +150,7 @@ Since values are stored positionally rather than keyed by expression text, there
 
 ### Behavior with variadic functions
 
-Functions that accept variadic arguments will receive the three desugared arguments. For example, Roblox's `print` concatenates its arguments with spaces:
+Functions that accept variadic arguments will receive the three desugared arguments. For example, `print` concatenates its arguments with spaces:
 
 ```luau
 local name = "Alice"
@@ -270,7 +270,7 @@ This distinction is intentional and valuable for DSL use cases, but documentatio
 
 ### Surprising behavior with existing functions
 
-Existing functions that are not designed for this calling convention will receive unexpected arguments if called without parentheses. For example, in Roblox, `print` and `warn` accept variadic arguments and would print the format string, values table, and expressions table alongside each other rather than producing a formatted message.
+Existing functions that are not designed for this calling convention will receive unexpected arguments if called without parentheses. For example, `print` and `warn` accept variadic arguments and would print the format string, values table, and expressions table alongside each other rather than producing a formatted message.
 
 Functions designed for parentheses-free interpolated string calls would need to be written (or updated, if possible) to accept the three-argument format. When an existing function cannot be updated in a non-breaking way (for example, because it accepts variadic arguments), a pattern such as the `Message` wrapper type described in the Design section can be used instead to bridge the gap.
 

--- a/docs/syntax-interpolated-string-function-calls.md
+++ b/docs/syntax-interpolated-string-function-calls.md
@@ -2,7 +2,13 @@
 
 ## Summary
 
-Allow calling functions with interpolated string literals without parentheses. The call is desugared into a function call with two arguments: the original template string (with interpolation expressions intact) and a table of the evaluated values. Two new core library functions are also introduced: one for extracting the stringified interpolation expressions from a template, and one for rendering a template with values. These reuse the same code as normal string interpolation. Together, this enables domain-specific language patterns like structured logging, SQL escaping, and HTML templating.
+Allow calling functions with interpolated string literals without parentheses
+
+The call is desugared into a function call with a table argument.  This table contains an array of string literal segments and the evaluated values from the substitution tokens.
+
+A new core library function is also introduced for performing typical default string interpolation.
+
+This enables domain-specific language patterns like SQL escaping, and HTML templating.
 
 ## Motivation
 
@@ -24,40 +30,41 @@ The [string interpolation RFC](https://github.com/luau-lang/rfcs/blob/master/doc
 
 This proposal lifts that restriction with semantics that decompose the interpolated string into its constituent parts, passing them to the called function. This enables the function to process the template and values however it sees fit, and to recover expression metadata via core library functions.
 
-### Structured logging
+### AST rewrites
 
-The primary motivating use case is structured logging. Production log consumption systems have two key requirements:
+[lute](https://lute.luau.org/) includes a powerful query system for searching and making procedural edits to Luau code.
 
-1. **Human-readable template strings** for aggregation. Logs need to be grouped by message pattern so that operators can see, for example, "200 instances/minute of '{foo} occurred after {bar}'" rather than an opaque format string or fingerprint.
-
-2. **Key-value structured data** for search and filtering. Given a template like `{user.name} logged in from {ip}`, the consuming system needs both the expression names (`user.name`, `ip`) and their runtime values (`"Alice"`, `"10.0.0.1"`) to enable queries like "show me all logs where user.name = 'Alice'".
-
-This proposal satisfies both requirements. The template string is passed directly as the first argument, and the core library function `string.interpparse` allows consumers to extract expression names and associate them with values:
+For example, a simple rewrite rule that replaces `expr ~= expr` with `math.isnan(expr)` is today written like so:
 
 ```luau
-local a = 1
-local function double(x: number)
-  return x * 2
+local query = require("@std/syntax/query")
+local syntax = require("@std/syntax")
+local syntax_utils = require("@std/syntax/utils")
+
+local function transform(ctx)
+    return query
+        .findallfromroot(ctx.parseresult.root, syntax_utils.isExprBinary)
+        :filter(function(bin)
+            return bin.operator.text == "~="
+                and bin.lhsoperand.tag == "local"
+                and bin.rhsoperand.tag == "local"
+                and bin.lhsoperand.token.text == bin.rhsoperand.token.text
+        end)
+        :replace(function(bin)
+            return `math.isnan({(bin.lhsoperand :: syntax.AstExprLocal).token.text})`
+        end)
 end
 
--- Desugars to: log:Info("The double of {a} is {double(a)}", {a, double(a)})
-log:Info `The double of {a} is {double(a)}`
+return transform
 ```
 
-The template `"The double of {a} is {double(a)}"` serves directly as an aggregation key, and a consumer can extract the expression names `"a"` and `"double(a)"` via `string.interpparse`.
+[https://github.com/luau-lang/lute/blob/primary/examples/query\_transformer.luau\#L15](https://github.com/luau-lang/lute/blob/primary/examples/query_transformer.luau#L15)
 
-These template strings are substantially more useful than format strings with opaque `%*` placeholders. Compare these two log call sites:
+With interpolated string function calls, the replacement expression can be expressed in a much clearer way:
 
-```luau
-log `{query} returned {result} in {duration}ms`
-log `{endpoint} returned {status} in {duration}ms`
 ```
-
-With template strings, these aggregate separately, so operators can distinguish database queries from HTTP requests. With `%*` format strings, both produce `"%* returned %* in %*ms"` and would merge into a single bucket. Call stack metadata (e.g. fingerprints) could be used to disambiguate, but the resulting aggregation keys are opaque and require a source code lookup to interpret.
-
-Template strings also make aggregated log patterns self-documenting. An operator seeing a pattern like `"%*: %* %*:%* -> %*:%* proto=%* bytes=%*"` in a dashboard cannot map the first four `%*` to meaning without a source code lookup. The template `"{rule_id}: {action} {src_ip}:{src_port} -> {dst_ip}:{dst_port} proto={proto} bytes={bytes}"` is immediately interpretable.
-
-Without this feature, developers must either manually construct all arguments (tedious and error-prone) or use a logging library that implements its own template parsing at runtime (duplicating language functionality).
+return ast`math.isnan({bin.lhsoperand})`
+```
 
 ### SQL escaping
 
@@ -67,9 +74,8 @@ Interpolated string calls enable safe, ergonomic SQL query construction where th
 local sqlite = require("luau_sqlite")
 
 local function takeUserInput(db: sqlite.DB, user: string, comment: string)
-  -- Auto-escape inputs to guard against SQL injection
-  db:Exec `INSERT INTO user_inputs (user, comment) VALUES ({user}, {comment})`
-  -- Desugars to: db:Exec("INSERT INTO user_inputs (user, comment) VALUES ({user}, {comment})", {user, comment})
+    -- Auto-escape inputs to guard against SQL injection
+    db:Exec `INSERT INTO user_inputs (user, comment) VALUES ({user}, {comment})`
 end
 ```
 
@@ -81,10 +87,12 @@ Similarly, HTML renderers can automatically escape interpolated values to preven
 local tmpl = require("luau_html_renderer")
 
 local function renderPage(r: tmpl.Renderer, userinput: string)
-  -- Automatic XSS protection through escaping
-  return tmpl.HTML `The user asked about {userinput}`
-  -- Desugars to: tmpl.HTML("The user asked about {userinput}", {userinput})
+    -- Automatic XSS protection through escaping
+    return tmpl.HTML `The user asked about {userinput}`
 end
+
+local bookName = "Pride & Prejudice"
+local para = tmpl.HTML `<p>Book name: {bookName}</p>` -- <p>Book name: Pride &amp; Prejudice</p>
 ```
 
 ## Design
@@ -100,71 +108,72 @@ args ::= '(' [explist] ')' | tableconstructor | LiteralString | stringinterp
 
 ### Semantics
 
-When a function is called with an interpolated string literal in this style, the compiler desugars the call into a function call with two arguments:
-
-1. **Template string**: The original template with interpolation expressions intact, e.g. `"The double of {a} is {double(a)}"`
-2. **Values table**: A sequential table of the evaluated interpolation values, e.g. `{a, double(a)}`
-
-The template string is determined at compile time. The values table is evaluated at runtime.
-
-For method calls (`:` syntax), `self` is passed first as usual, followed by these two arguments.
-
-If the interpolated string contains no interpolation expressions, the call passes a single string argument (the literal string), identical to a regular string literal call.
-
-### Core library functions
-
-Two new functions are added to the `string` library to support consumers of interpolated string calls. Both reuse the same code as the compiler's normal string interpolation implementation.
-
-#### `string.interpparse`
+When a function is called with an interpolated string literal in this style, the compiler will desugar the expression to a function call of the following form:
 
 ```luau
-string.interpparse(template: string) -> {string}
+f `Template string {expr1} content {expr2} ...`
+
+-- to
+
+f(
+    string.interpolatedstring.create(
+        {"Template string ", " content ", " ..."},
+        {expr1, expr2},
+    )
+)
 ```
 
-Parses an interpolation template and returns a sequential table of the stringified interpolation expressions.
+The function is passed a table with two keys:
+
+1. `strings` – an array containing all of the string literal sections of the template string, and
+2. `expressions` – An array containing the values to be substituted in
+
+To handle the case that any interior `expression` may be `nil`, the desugaring ensures that `#strings` is always one greater than `#expressions`.  If the template string starts or ends with an expression, the first or last elements of `strings` will be the empty string.
 
 ```luau
-string.interpparse("Hello {name}")          -- returns {"name"}
-string.interpparse("{a} + {b} = {a + b}")   -- returns {"a", "b", "a + b"}
-string.interpparse("No interpolations")     -- returns {}
+f `{expr1} {expr2}` --> f(string.interpolatedstring.create({"", " ", ""}, {expr1, expr2})
 ```
 
-#### `string.interp`
+The table `string.interpolatedstring` is added to the standard `string` library.  Its contents are roughly
 
 ```luau
-string.interp(template: string, values: {any}) -> string
+string.interpolatedstring = table.freeze({
+    __tostring=...,
+    __concat=...,
+    __len=...,
+    create=function (strings, expressions)
+        return setmetatable({strings=strings, expressions=expressions}, string.interpolatedstring)
+    end
+})
 ```
 
-Renders an interpolation template by replacing each `{expression}` with the `tostring` of the corresponding value from the values table, matching the behavior of normal string interpolation. The values table may be either sequential (positional matching) or associative with string keys (matching by expression name):
+Where each of the metafunctions acts to make the interpolated string value behave somewhat like an ordinary string.
+
+## Core library functions
+
+A new function `string.interpolate` is added to afford easy access to the default interpolation algorithm.
 
 ```luau
--- Sequential: values matched positionally to expressions
-string.interp("Hello {name}", {"Alice"})          -- returns "Hello Alice"
-string.interp("{a} + {b} = {a + b}", {1, 2, 3})   -- returns "1 + 2 = 3"
-
--- Associative: values matched by expression name
-string.interp("Hello {name}", {name = "Alice"})   -- returns "Hello Alice"
-```
-
-Supporting both sequential and associative tables enables a single function to serve as both a parentheses-free interpolated string call target and a conventional function accepting a template with a named context object:
-
-```luau
-function log_info(self, template, values)
-    local exprs = string.interpparse(template)
-    local rendered = string.interp(template, values)
-    -- exprs[i] is the expression name, values[i] is the runtime value
-    -- rendered is the fully formatted string
+function string.interpolate(t: {strings: {string}, expressions: {unknown}})
+    local n = #t.strings - 1
+    local result = ""
+    for i = 1, n do
+        result ..= t.strings[i] .. tostring(t.expressions[i])
+    end
+    result ..= t.strings[#strings]
+    return result
 end
-
--- Paren-free: compiler fills in values positionally from local variables
-log:Info `Hello {name}`
--- Desugars to: log:Info("Hello {name}", {"Alice"})
-
--- Parenthesized: caller provides a named context object
-log:Info("Hello {name}", {name = "Alice"})
 ```
 
-Note that calling `string.interpparse` at runtime means the template is parsed twice: once by the compiler when desugaring the interpolated string call (to identify expressions and evaluate them), and a second time by the library function. This is a minor cost, as template strings are typically short. The implementation of `string.interpparse` can also cache results internally, since template strings are compile-time constants and strings are interned in Luau, making repeated calls with the same template effectively free.
+This function renders an interpolation template by replacing each `expression` with the `tostring` of the corresponding expression, matching the behavior of normal string interpolation.
+
+```luau
+local world = 'World'
+local s = string.interpolate `Hello {world}!`
+assert("Hello World!" == tostring(s))
+```
+
+This will be useful for any application that wants to augment the default string interpolation logic rather than replacing it.
 
 ### Examples
 
@@ -174,131 +183,54 @@ local user = {name = "Alice"}
 
 -- Simple identifier
 log:Info `Processing item {id}`
--- Desugars to: log:Info("Processing item {id}", {42})
 
 -- Member expression
 log:Info `User {user.name} logged in`
--- Desugars to: log:Info("User {user.name} logged in", {"Alice"})
 
 -- Multiple expressions
 log:Info `{user.name} is processing item {id}`
--- Desugars to: log:Info("{user.name} is processing item {id}", {"Alice", 42})
 ```
 
 ### No expression restrictions
 
-This design uses positional tables, so **any expression valid in a regular interpolated string is also valid here**, including function and method calls:
+This design uses positional tables, so any expression valid in a regular interpolated string is also valid here, including function and method calls:
 
 ```luau
 -- Function calls are allowed
 log:Info `Result is {compute()}`
--- Desugars to: log:Info("Result is {compute()}", {compute()})
+-- Desugars to: log:Info(string.interpolatedstring.create({"Result is ", ""}, {compute()})
 
 -- Method calls are allowed
 log:Info `Name is {user:getName()}`
--- Desugars to: log:Info("Name is {user:getName()}", {user:getName()})
+-- Desugars to: log:Info(string.interpolatedstring.create({"Name is ", ""}, {user:getName()})
 
 -- Repeated expressions are fine (each is a separate positional entry)
 log:Info `{increment()} and then {increment()}`
--- Desugars to: log:Info("{increment()} and then {increment()}", {increment(), increment()})
+-- Desugars to: log:Info(string.interpolatedstring.create({"", " and then ", ""}, {increment(), increment()}))
 ```
 
 Since values are stored positionally rather than keyed by expression text, there is no ambiguity when the same expression appears multiple times or when expressions have side effects.
 
 ### Behavior with variadic functions
 
-Functions that accept variadic arguments will receive the two desugared arguments. For example, `print` concatenates its arguments with spaces:
-
 ```luau
 local name = "Alice"
 print `Hello {name}`
--- Desugars to: print("Hello {name}", {"Alice"})
--- Output: Hello {name} table: 0x...
+-- Desugars to: print(string.interpolatedstring.create({"Hello ", ""}, {name}))
+-- Output: Hello Alice
 ```
 
-This is likely not the desired output. Developers wanting simple string interpolation should use parentheses:
-
-```luau
-print(`Hello {name}`)  -- Output: Hello Alice
-```
-
-The parentheses-free form is intended for functions specifically designed to receive the expanded arguments.
+This works because the result of `string.interpolatedstring.create` provides the `__tostring` metamethod.  It is not a string, but can easily be used like a string in simple cases.
 
 ### Interaction with existing syntax
 
-This feature does not change the behavior of:
+All existing valid function call syntaxes are unchanged:
 
-- Regular string literals: `print "hello"` continues to pass a single string argument
-- Table literals: `print {1, 2, 3}` continues to pass a single table argument
-- Parenthesized calls: `print(`hello {name}`)` continues to pass a single formatted string
+- Regular string literals: `print "hello"`
+- Table literals: `print {1, 2, 3}`
+- Parenthesized calls: ``print(`hello {name}`)``
 
 The new behavior only applies to calls without parentheses using interpolated strings.
-
-### Passing additional context via currying
-
-Some use cases (e.g. structured logging) benefit from passing additional context alongside the interpolated string. Rather than introducing special syntax for an extra argument, this can be achieved through currying (a function that returns a function):
-
-```luau
--- log accepts the desugared interpolated string arguments and returns
--- a function that accepts additional context
-function log(template, vals)
-  return function(context)
-    local rendered = string.interp(template, vals)
-    emit(rendered, template, vals, context)
-  end
-end
-
--- No parentheses anywhere -- log is called with the desugared
--- interpolated string and returns a function, which is then called
--- with the context table
-log `Hello {name}` {userId = 12345, region = "us-east"}
-
--- Desugars to: log("Hello {name}", {"Alice"})({userId = 12345, region = "us-east"})
-```
-
-This approach requires no special grammar support. It is a natural composition of a parentheses-free interpolated string call (which returns a function) and a parentheses-free table literal call on that returned function.
-
-### Bridging to existing functions with a `Message` type
-
-A `Message` wrapper type can bridge the gap between this calling convention and existing functions like `print` or `warn` that expect string arguments:
-
-```luau
-local Message = {}
-Message.__index = Message
-
-function Message.new(template, vals)
-  return setmetatable({
-    template = template,
-    values = vals,
-  }, Message)
-end
-
-function Message:__tostring()
-  return string.interp(self.template, self.values)
-end
-```
-
-Because `Message` defines `__tostring`, existing functions that convert arguments to strings will produce the expected formatted output:
-
-```luau
--- Message.new receives the desugared arguments and returns a Message object
--- print() calls tostring on it, producing "Hello Alice"
-print(Message.new `Hello {name}`)
-
--- warn works the same way
-warn(Message.new `User {user.name} failed to log in`)
-```
-
-Structured logging APIs can also inspect the Message's fields directly:
-
-```luau
-function structured_log(msg: Message)
-  local exprs = string.interpparse(msg.template)
-  emit(tostring(msg), msg.template, msg.values, exprs)
-end
-```
-
-While not part of this proposal, this pattern also opens the door for existing functions to be updated to special-case a single `Message` argument, extracting structured data for telemetry while preserving their current behavior for all other callers.
 
 ## Drawbacks
 
@@ -306,28 +238,33 @@ While not part of this proposal, this pattern also opens the door for existing f
 
 Adding interpolated strings as a parentheses-free call argument adds complexity to the parser. However, the grammar change is minimal and unambiguous.
 
-### Learning curve
+### Interpolated strings aren't (quite) strings
 
-Developers need to understand that interpolated string calls without parentheses behave differently from parenthesized calls. This could be confusing:
+The value passed to an interpolated string function call behaves a little bit like a string, and can easily be converted into a string, but it isn't actually a string.  It cannot be passed to `string.sub` for instance.
 
-```luau
-log:Info `Hello {name}`        -- passes 2 arguments (template, values)
-log:Info(`Hello {name}`)       -- passes 1 argument (formatted string)
-```
+The static type system can catch this for developers who use it, but it may trip up some users from time to time.
 
-This distinction is intentional and valuable for DSL use cases, but documentation will need to clearly explain the difference.
+### Every call is 3 tables
 
-### Surprising behavior with existing functions
-
-Existing functions that are not designed for this calling convention will receive unexpected arguments if called without parentheses. For example, `print` and `warn` accept variadic arguments and would print the template string and values table rather than producing a formatted message.
-
-Functions designed for parentheses-free interpolated string calls would need to be written (or updated, if possible) to accept the two-argument format. When an existing function cannot be updated in a non-breaking way (for example, because it accepts variadic arguments), a pattern such as the `Message` wrapper type described in the Design section can be used instead to bridge the gap.
-
-### Double parsing of template strings
-
-When a consumer calls `string.interpparse`, the template string is parsed twice: once by the compiler when desugaring the call, and once at runtime by the library function. While this cost is minor for typical template strings, it is inherently redundant. The [three-argument desugaring with byte offsets](#three-argument-desugaring-with-byte-offsets) alternative avoids this by providing expression location data at compile time.
+This isn't the worst thing, but it'll be a tiny bit less efficient than what you'd write if you did things by hand.  The extra enclosing table is worth it because it encapsulates everything into a single value with a useful metatable.
 
 ## Alternatives
+
+### Including the source text in the desugaring
+
+An early motivating use case for this feature was to afford nice syntax to a structured logging API.
+
+We debated this for quite some time, but came to the conclusion that, even if we did offer this, it wouldn't enable quite the kind of structured logging API that we were looking for.
+
+Since there were no other motivating use cases that called for extracting the original substitution tokens, this feature has been dropped from the proposal.
+
+### Three-argument desugaring
+
+A previous iteration we considered was for the call to desugar to a function call accepting two or three arguments: A list of string literals, a list of expressions to be intercalated between, and a list of the stringifications of the expressions.
+
+We chose not to move forward with this design because it interacts very badly with functions that are intended to work with actual strings.  For example, under this design, the statement  `` print `my template string` `` would be completely valid, but would actually print out the memory addresses of two or three tables!
+
+This was deemed unacceptably confusing.
 
 ### Three-argument desugaring with byte offsets
 
@@ -349,7 +286,7 @@ local span = string.sub(template, offsets[i][1], offsets[i][1] + offsets[i][2] -
 local expr = string.sub(template, offsets[i][1] + 1, offsets[i][1] + offsets[i][2] - 2)
 ```
 
-This approach avoids the double-parsing drawback since all expression metadata is provided at compile time. However, it passes a more complex calling convention (three arguments instead of two) and requires every consumer to manually perform byte arithmetic to extract expression names. Additionally, reconstructing the formatted string requires the consumer to implement its own replacement loop using the byte offsets rather than calling a single library function.
+This approach avoids the double-parsing drawback since all expression metadata is provided at compile time. However it requires every consumer to manually perform byte arithmetic to extract expression names.
 
 ### Interpolation metadata object syntax
 
@@ -366,7 +303,7 @@ db:Exec(@`SELECT * FROM users WHERE id = {userId}`)
 
 The `@` prefix before an interpolated string would evaluate to a structured object containing the template, values, and parsed expression names. This object could be passed to any function using normal parenthesized call syntax, stored in variables, placed in data structures, etc.
 
-This approach avoids the learning-curve issue of parenthesized vs. non-parenthesized calls having different semantics for interpolated strings. It also makes the intent explicit at the call site. However, it introduces new syntax (`@` prefix) for a feature that is also achievable through the parentheses-free calling convention, and it loses the concise DSL aesthetic of `log `message`` in favor of `log(@`message`)`.
+This approach avoids the learning-curve issue of parenthesized vs. non-parenthesized calls having different semantics for interpolated strings. It also makes the intent explicit at the call site. However, it introduces new syntax (`@` prefix) for a feature that is also achievable through the parentheses-free calling convention and introduces a new type of value which would need a clearly defined interface.
 
 ### Manual format string with curried values
 
@@ -374,10 +311,10 @@ As noted by reviewers, a similar pattern is already achievable without new synta
 
 ```luau
 local function Log(fmt: string)
-  return function(args: { any })
-    local message = string.format(fmt, table.unpack(args))
-    print("Log:", message, "Format:", fmt)
-  end
+    return function(args: { any })
+        local message = string.format(fmt, table.unpack(args))
+        print("Log:", message, "Format:", fmt)
+    end
 end
 
 local user = "Bottersnike"
@@ -392,17 +329,6 @@ While this works for simple cases, it has significant limitations:
 
 This RFC automates the decomposition that developers would otherwise have to do by hand, while preserving the original template and expression metadata.
 
-### Expressions list instead of byte offsets
-
-Instead of core library functions, the compiler could pass expression source texts directly as a third argument:
-
-```luau
-log:Info `Hello {name}`
--- Would pass: log:Info("Hello {name}", {"Alice"}, {"name"})
-```
-
-This avoids the double-parsing drawback of the core library function approach and is slightly more convenient for consumers who only need expression names. However, it requires the language specification to define normalization rules for source text (whitespace trimming, quote handling for literals, etc.) and adds a third argument to the calling convention. The core library function approach handles normalization in the library implementation without burdening the calling convention.
-
 ### Tagged interpolated strings (JavaScript-style)
 
 JavaScript's tagged template literals pass an array of string parts and the interpolated values as separate arguments:
@@ -412,14 +338,16 @@ tag`Hello ${name}, you have ${count} messages`;
 // Calls: tag(["Hello ", ", you have ", " messages"], name, count)
 ```
 
-A Luau adaptation would pass two tables, string parts and values:
+We considered a Luau adaptation:
 
 ```luau
 tag `Hello {name}, you have {count} messages`
--- Would call: tag({"Hello ", ", you have ", " messages"}, {name, count})
+-- Would call: tag({"Hello ", ", you have ", " messages"}, name, count)
 ```
 
-This was considered and the proposed design shares the same spirit: decomposing the interpolated string into parts that don't require the consumer to parse Luau expressions. The proposed design differs in preserving the original template string (useful as an aggregation key) and providing library functions for flexible extraction of expression metadata.
+This was considered and the proposed design shares the same spirit: decomposing the interpolated string into parts that don't require the consumer to parse Luau expressions. The proposed design allows recovering the original template string (useful as an aggregation key) and providing library functions for flexible extraction of expression metadata.
+
+The current proposal is very much a spiritual extension of this, but with the improvement that the interpolated string is passed as just one value.  This value can be used by any function that naively stringifies its argument (like `print`).  It can also be augmented with more keys later.
 
 ### Interpolation table with named keys
 
@@ -451,4 +379,4 @@ This was rejected because it adds ambiguity to the grammar and is overly specifi
 
 ## References
 
-- [String interpolation RFC](https://github.com/luau-lang/rfcs/blob/master/docs/syntax-string-interpolation.md) - The original RFC that introduced interpolated strings and noted the temporary restriction
+- [String interpolation RFC](https://github.com/luau-lang/rfcs/blob/master/docs/syntax-string-interpolation.md) \- The original RFC that introduced interpolated strings and noted the temporary restriction

--- a/docs/syntax-interpolated-string-function-calls.md
+++ b/docs/syntax-interpolated-string-function-calls.md
@@ -116,7 +116,7 @@ f `Template string {expr1} content {expr2} ...`
 -- to
 
 f(
-    string.interpolatedstring.create(
+    string.interpolated.create(
         {"Template string ", " content ", " ..."},
         {expr1, expr2},
     )
@@ -131,49 +131,23 @@ The function is passed a table with two keys:
 To handle the case that any interior `expression` may be `nil`, the desugaring ensures that `#strings` is always one greater than `#expressions`.  If the template string starts or ends with an expression, the first or last elements of `strings` will be the empty string.
 
 ```luau
-f `{expr1} {expr2}` --> f(string.interpolatedstring.create({"", " ", ""}, {expr1, expr2})
+f `{expr1} {expr2}` --> f(string.interpolated.create({"", " ", ""}, {expr1, expr2})
 ```
 
-The table `string.interpolatedstring` is added to the standard `string` library.  Its contents are roughly
+The table `string.interpolated` is added to the standard `string` library.  Its contents are roughly
 
 ```luau
-string.interpolatedstring = table.freeze({
+string.interpolated = table.freeze({
     __tostring=...,
     __concat=...,
     __len=...,
     create=function (strings, expressions)
-        return setmetatable({strings=strings, expressions=expressions}, string.interpolatedstring)
+        return setmetatable({strings=strings, expressions=expressions}, string.interpolated)
     end
 })
 ```
 
 Where each of the metafunctions acts to make the interpolated string value behave somewhat like an ordinary string.
-
-## Core library functions
-
-A new function `string.interpolate` is added to afford easy access to the default interpolation algorithm.
-
-```luau
-function string.interpolate(t: {strings: {string}, expressions: {unknown}})
-    local n = #t.strings - 1
-    local result = ""
-    for i = 1, n do
-        result ..= t.strings[i] .. tostring(t.expressions[i])
-    end
-    result ..= t.strings[#strings]
-    return result
-end
-```
-
-This function renders an interpolation template by replacing each `expression` with the `tostring` of the corresponding expression, matching the behavior of normal string interpolation.
-
-```luau
-local world = 'World'
-local s = string.interpolate `Hello {world}!`
-assert("Hello World!" == tostring(s))
-```
-
-This will be useful for any application that wants to augment the default string interpolation logic rather than replacing it.
 
 ### Examples
 
@@ -198,15 +172,15 @@ This design uses positional tables, so any expression valid in a regular interpo
 ```luau
 -- Function calls are allowed
 log:Info `Result is {compute()}`
--- Desugars to: log:Info(string.interpolatedstring.create({"Result is ", ""}, {compute()})
+-- Desugars to: log:Info(string.interpolated.create({"Result is ", ""}, {compute()})
 
 -- Method calls are allowed
 log:Info `Name is {user:getName()}`
--- Desugars to: log:Info(string.interpolatedstring.create({"Name is ", ""}, {user:getName()})
+-- Desugars to: log:Info(string.interpolated.create({"Name is ", ""}, {user:getName()})
 
 -- Repeated expressions are fine (each is a separate positional entry)
 log:Info `{increment()} and then {increment()}`
--- Desugars to: log:Info(string.interpolatedstring.create({"", " and then ", ""}, {increment(), increment()}))
+-- Desugars to: log:Info(string.interpolated.create({"", " and then ", ""}, {increment(), increment()}))
 ```
 
 Since values are stored positionally rather than keyed by expression text, there is no ambiguity when the same expression appears multiple times or when expressions have side effects.
@@ -216,11 +190,11 @@ Since values are stored positionally rather than keyed by expression text, there
 ```luau
 local name = "Alice"
 print `Hello {name}`
--- Desugars to: print(string.interpolatedstring.create({"Hello ", ""}, {name}))
+-- Desugars to: print(string.interpolated.create({"Hello ", ""}, {name}))
 -- Output: Hello Alice
 ```
 
-This works because the result of `string.interpolatedstring.create` provides the `__tostring` metamethod.  It is not a string, but can easily be used like a string in simple cases.
+This works because the result of `string.interpolated.create` provides the `__tostring` metamethod.  It is not a string, but can easily be used like a string in simple cases.
 
 ### Interaction with existing syntax
 

--- a/docs/syntax-interpolated-string-function-calls.md
+++ b/docs/syntax-interpolated-string-function-calls.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Allow calling functions with interpolated string literals without parentheses. The call is desugared into a function call with three arguments: the original template string (with interpolation expressions intact), a table of the evaluated values, and a table of byte-offset/length pairs locating each interpolation expression within the template. This enables domain-specific language patterns like structured logging, SQL escaping, and HTML templating.
+Allow calling functions with interpolated string literals without parentheses. The call is desugared into a function call with two arguments: the original template string (with interpolation expressions intact) and a table of the evaluated values. Two new core library functions are also introduced: one for extracting the stringified interpolation expressions from a template, and one for rendering a template with values. These reuse the same code as normal string interpolation. Together, this enables domain-specific language patterns like structured logging, SQL escaping, and HTML templating.
 
 ## Motivation
 
@@ -22,7 +22,7 @@ print `Hello {name}`  -- currently a parse error
 
 The [string interpolation RFC](https://github.com/luau-lang/rfcs/blob/master/docs/syntax-string-interpolation.md) noted this restriction was "likely temporary while we work through string interpolation DSLs."
 
-This proposal lifts that restriction with semantics that decompose the interpolated string into its constituent parts, passing them to the called function. This enables the function to process the template, values, and expression metadata however it sees fit, without needing to implement its own string parser.
+This proposal lifts that restriction with semantics that decompose the interpolated string into its constituent parts, passing them to the called function. This enables the function to process the template and values however it sees fit, and to recover expression metadata via core library functions.
 
 ### Structured logging
 
@@ -32,7 +32,7 @@ The primary motivating use case is structured logging. Production log consumptio
 
 2. **Key-value structured data** for search and filtering. Given a template like `{user.name} logged in from {ip}`, the consuming system needs both the expression names (`user.name`, `ip`) and their runtime values (`"Alice"`, `"10.0.0.1"`) to enable queries like "show me all logs where user.name = 'Alice'".
 
-This proposal satisfies both requirements. The template string is passed directly as the first argument, and the byte offsets allow consumers to extract expression names and associate them with values:
+This proposal satisfies both requirements. The template string is passed directly as the first argument, and the core library function `string.interpparse` allows consumers to extract expression names and associate them with values:
 
 ```luau
 local a = 1
@@ -40,11 +40,11 @@ local function double(x: number)
   return x * 2
 end
 
--- Desugars to: log:Info("The double of {a} is {double(a)}", {a, double(a)}, {{15, 3}, {22, 11}})
+-- Desugars to: log:Info("The double of {a} is {double(a)}", {a, double(a)})
 log:Info `The double of {a} is {double(a)}`
 ```
 
-The template `"The double of {a} is {double(a)}"` serves directly as an aggregation key, and a consumer can extract the expression names `"a"` and `"double(a)"` via the byte offsets.
+The template `"The double of {a} is {double(a)}"` serves directly as an aggregation key, and a consumer can extract the expression names `"a"` and `"double(a)"` via `string.interpparse`.
 
 These template strings are substantially more useful than format strings with opaque `%*` placeholders. Compare these two log call sites:
 
@@ -69,7 +69,7 @@ local sqlite = require("luau_sqlite")
 local function takeUserInput(db: sqlite.DB, user: string, comment: string)
   -- Auto-escape inputs to guard against SQL injection
   db:Exec `INSERT INTO user_inputs (user, comment) VALUES ({user}, {comment})`
-  -- Desugars to: db:Exec("INSERT INTO user_inputs (user, comment) VALUES ({user}, {comment})", {user, comment}, {{47, 6}, {55, 9}})
+  -- Desugars to: db:Exec("INSERT INTO user_inputs (user, comment) VALUES ({user}, {comment})", {user, comment})
 end
 ```
 
@@ -83,7 +83,7 @@ local tmpl = require("luau_html_renderer")
 local function renderPage(r: tmpl.Renderer, userinput: string)
   -- Automatic XSS protection through escaping
   return tmpl.HTML `The user asked about {userinput}`
-  -- Desugars to: tmpl.HTML("The user asked about {userinput}", {userinput}, {{22, 11}})
+  -- Desugars to: tmpl.HTML("The user asked about {userinput}", {userinput})
 end
 ```
 
@@ -100,26 +100,71 @@ args ::= '(' [explist] ')' | tableconstructor | LiteralString | stringinterp
 
 ### Semantics
 
-When a function is called with an interpolated string literal in this style, the compiler desugars the call into a function call with three arguments:
+When a function is called with an interpolated string literal in this style, the compiler desugars the call into a function call with two arguments:
 
 1. **Template string**: The original template with interpolation expressions intact, e.g. `"The double of {a} is {double(a)}"`
 2. **Values table**: A sequential table of the evaluated interpolation values, e.g. `{a, double(a)}`
-3. **Offsets table**: A sequential table of `{offset, length}` pairs, where each pair gives the 1-based byte offset and length of the corresponding `{expression}` span (including braces) within the template string
 
-The template string and offsets table are determined at compile time. The values table is evaluated at runtime.
+The template string is determined at compile time. The values table is evaluated at runtime.
 
-A consumer can extract the expression text for the i-th interpolation using the offsets:
-
-```luau
--- Extract {expr} including braces
-local span = string.sub(template, offsets[i][1], offsets[i][1] + offsets[i][2] - 1)
--- Extract just the expression name (strip braces)
-local expr = string.sub(template, offsets[i][1] + 1, offsets[i][1] + offsets[i][2] - 2)
-```
-
-For method calls (`:` syntax), `self` is passed first as usual, followed by these three arguments.
+For method calls (`:` syntax), `self` is passed first as usual, followed by these two arguments.
 
 If the interpolated string contains no interpolation expressions, the call passes a single string argument (the literal string), identical to a regular string literal call.
+
+### Core library functions
+
+Two new functions are added to the `string` library to support consumers of interpolated string calls. Both reuse the same code as the compiler's normal string interpolation implementation.
+
+#### `string.interpparse`
+
+```luau
+string.interpparse(template: string) -> {string}
+```
+
+Parses an interpolation template and returns a sequential table of the stringified interpolation expressions.
+
+```luau
+string.interpparse("Hello {name}")          -- returns {"name"}
+string.interpparse("{a} + {b} = {a + b}")   -- returns {"a", "b", "a + b"}
+string.interpparse("No interpolations")     -- returns {}
+```
+
+#### `string.interp`
+
+```luau
+string.interp(template: string, values: {any}) -> string
+```
+
+Renders an interpolation template by replacing each `{expression}` with the `tostring` of the corresponding value from the values table, matching the behavior of normal string interpolation. The values table may be either sequential (positional matching) or associative with string keys (matching by expression name):
+
+```luau
+-- Sequential: values matched positionally to expressions
+string.interp("Hello {name}", {"Alice"})          -- returns "Hello Alice"
+string.interp("{a} + {b} = {a + b}", {1, 2, 3})   -- returns "1 + 2 = 3"
+
+-- Associative: values matched by expression name
+string.interp("Hello {name}", {name = "Alice"})   -- returns "Hello Alice"
+```
+
+Supporting both sequential and associative tables enables a single function to serve as both a parentheses-free interpolated string call target and a conventional function accepting a template with a named context object:
+
+```luau
+function log_info(self, template, values)
+    local exprs = string.interpparse(template)
+    local rendered = string.interp(template, values)
+    -- exprs[i] is the expression name, values[i] is the runtime value
+    -- rendered is the fully formatted string
+end
+
+-- Paren-free: compiler fills in values positionally from local variables
+log:Info `Hello {name}`
+-- Desugars to: log:Info("Hello {name}", {"Alice"})
+
+-- Parenthesized: caller provides a named context object
+log:Info("Hello {name}", {name = "Alice"})
+```
+
+Note that calling `string.interpparse` at runtime means the template is parsed twice: once by the compiler when desugaring the interpolated string call (to identify expressions and evaluate them), and a second time by the library function. This is a minor cost, as template strings are typically short. The implementation of `string.interpparse` can also cache results internally, since template strings are compile-time constants and strings are interned in Luau, making repeated calls with the same template effectively free.
 
 ### Examples
 
@@ -129,15 +174,15 @@ local user = {name = "Alice"}
 
 -- Simple identifier
 log:Info `Processing item {id}`
--- Desugars to: log:Info("Processing item {id}", {42}, {{17, 4}})
+-- Desugars to: log:Info("Processing item {id}", {42})
 
 -- Member expression
 log:Info `User {user.name} logged in`
--- Desugars to: log:Info("User {user.name} logged in", {"Alice"}, {{6, 11}})
+-- Desugars to: log:Info("User {user.name} logged in", {"Alice"})
 
 -- Multiple expressions
 log:Info `{user.name} is processing item {id}`
--- Desugars to: log:Info("{user.name} is processing item {id}", {"Alice", 42}, {{1, 11}, {33, 4}})
+-- Desugars to: log:Info("{user.name} is processing item {id}", {"Alice", 42})
 ```
 
 ### No expression restrictions
@@ -147,28 +192,28 @@ This design uses positional tables, so **any expression valid in a regular inter
 ```luau
 -- Function calls are allowed
 log:Info `Result is {compute()}`
--- Desugars to: log:Info("Result is {compute()}", {compute()}, {{11, 11}})
+-- Desugars to: log:Info("Result is {compute()}", {compute()})
 
 -- Method calls are allowed
 log:Info `Name is {user:getName()}`
--- Desugars to: log:Info("Name is {user:getName()}", {user:getName()}, {{9, 17}})
+-- Desugars to: log:Info("Name is {user:getName()}", {user:getName()})
 
 -- Repeated expressions are fine (each is a separate positional entry)
 log:Info `{increment()} and then {increment()}`
--- Desugars to: log:Info("{increment()} and then {increment()}", {increment(), increment()}, {{1, 13}, {25, 13}})
+-- Desugars to: log:Info("{increment()} and then {increment()}", {increment(), increment()})
 ```
 
 Since values are stored positionally rather than keyed by expression text, there is no ambiguity when the same expression appears multiple times or when expressions have side effects.
 
 ### Behavior with variadic functions
 
-Functions that accept variadic arguments will receive the three desugared arguments. For example, `print` concatenates its arguments with spaces:
+Functions that accept variadic arguments will receive the two desugared arguments. For example, `print` concatenates its arguments with spaces:
 
 ```luau
 local name = "Alice"
 print `Hello {name}`
--- Desugars to: print("Hello {name}", {"Alice"}, {{7, 6}})
--- Output: Hello {name} table: 0x... table: 0x...
+-- Desugars to: print("Hello {name}", {"Alice"})
+-- Output: Hello {name} table: 0x...
 ```
 
 This is likely not the desired output. Developers wanting simple string interpolation should use parentheses:
@@ -196,16 +241,10 @@ Some use cases (e.g. structured logging) benefit from passing additional context
 ```luau
 -- log accepts the desugared interpolated string arguments and returns
 -- a function that accepts additional context
-function log(template, vals, offsets)
+function log(template, vals)
   return function(context)
-    -- The template (e.g. "Hello {name}") is already a human-readable aggregation key.
-    -- Build the formatted message by replacing {expr} spans with values.
-    local message = template
-    for i = #offsets, 1, -1 do
-      local pos, len = offsets[i][1], offsets[i][2]
-      message = string.sub(message, 1, pos - 1) .. tostring(vals[i]) .. string.sub(message, pos + len)
-    end
-    emit(message, template, vals, context)
+    local rendered = string.interp(template, vals)
+    emit(rendered, template, vals, context)
   end
 end
 
@@ -214,7 +253,7 @@ end
 -- with the context table
 log `Hello {name}` {userId = 12345, region = "us-east"}
 
--- Desugars to: log("Hello {name}", {"Alice"}, {{7, 6}})({userId = 12345, region = "us-east"})
+-- Desugars to: log("Hello {name}", {"Alice"})({userId = 12345, region = "us-east"})
 ```
 
 This approach requires no special grammar support. It is a natural composition of a parentheses-free interpolated string call (which returns a function) and a parentheses-free table literal call on that returned function.
@@ -227,21 +266,15 @@ A `Message` wrapper type can bridge the gap between this calling convention and 
 local Message = {}
 Message.__index = Message
 
-function Message.new(template, vals, offsets)
+function Message.new(template, vals)
   return setmetatable({
     template = template,
     values = vals,
-    offsets = offsets,
   }, Message)
 end
 
 function Message:__tostring()
-  local result = self.template
-  for i = #self.offsets, 1, -1 do
-    local pos, len = self.offsets[i][1], self.offsets[i][2]
-    result = string.sub(result, 1, pos - 1) .. tostring(self.values[i]) .. string.sub(result, pos + len)
-  end
-  return result
+  return string.interp(self.template, self.values)
 end
 ```
 
@@ -260,7 +293,8 @@ Structured logging APIs can also inspect the Message's fields directly:
 
 ```luau
 function structured_log(msg: Message)
-  emit(tostring(msg), msg.template, msg.values, msg.offsets)
+  local exprs = string.interpparse(msg.template)
+  emit(tostring(msg), msg.template, msg.values, exprs)
 end
 ```
 
@@ -277,7 +311,7 @@ Adding interpolated strings as a parentheses-free call argument adds complexity 
 Developers need to understand that interpolated string calls without parentheses behave differently from parenthesized calls. This could be confusing:
 
 ```luau
-log:Info `Hello {name}`        -- passes 3 arguments (template, values, offsets)
+log:Info `Hello {name}`        -- passes 2 arguments (template, values)
 log:Info(`Hello {name}`)       -- passes 1 argument (formatted string)
 ```
 
@@ -285,11 +319,54 @@ This distinction is intentional and valuable for DSL use cases, but documentatio
 
 ### Surprising behavior with existing functions
 
-Existing functions that are not designed for this calling convention will receive unexpected arguments if called without parentheses. For example, `print` and `warn` accept variadic arguments and would print the template string, values table, and offsets table alongside each other rather than producing a formatted message.
+Existing functions that are not designed for this calling convention will receive unexpected arguments if called without parentheses. For example, `print` and `warn` accept variadic arguments and would print the template string and values table rather than producing a formatted message.
 
-Functions designed for parentheses-free interpolated string calls would need to be written (or updated, if possible) to accept the three-argument format. When an existing function cannot be updated in a non-breaking way (for example, because it accepts variadic arguments), a pattern such as the `Message` wrapper type described in the Design section can be used instead to bridge the gap.
+Functions designed for parentheses-free interpolated string calls would need to be written (or updated, if possible) to accept the two-argument format. When an existing function cannot be updated in a non-breaking way (for example, because it accepts variadic arguments), a pattern such as the `Message` wrapper type described in the Design section can be used instead to bridge the gap.
+
+### Double parsing of template strings
+
+When a consumer calls `string.interpparse`, the template string is parsed twice: once by the compiler when desugaring the call, and once at runtime by the library function. While this cost is minor for typical template strings, it is inherently redundant. The [three-argument desugaring with byte offsets](#three-argument-desugaring-with-byte-offsets) alternative avoids this by providing expression location data at compile time.
 
 ## Alternatives
+
+### Three-argument desugaring with byte offsets
+
+Instead of two arguments and core library functions, the compiler could desugar the call into three arguments: the template string, the values table, and a table of byte-offset/length pairs locating each interpolation expression within the template:
+
+```luau
+log:Info `The double of {a} is {double(a)}`
+-- Would desugar to: log:Info("The double of {a} is {double(a)}", {a, double(a)}, {{15, 3}, {22, 11}})
+```
+
+The third argument is a sequential table of `{offset, length}` pairs, where each pair gives the 1-based byte offset and length of the corresponding `{expression}` span (including braces) within the template string. Both the template string and offsets table are determined at compile time; only the values table is evaluated at runtime.
+
+A consumer would extract expression text using the offsets:
+
+```luau
+-- Extract {expr} including braces
+local span = string.sub(template, offsets[i][1], offsets[i][1] + offsets[i][2] - 1)
+-- Extract just the expression name (strip braces)
+local expr = string.sub(template, offsets[i][1] + 1, offsets[i][1] + offsets[i][2] - 2)
+```
+
+This approach avoids the double-parsing drawback since all expression metadata is provided at compile time. However, it passes a more complex calling convention (three arguments instead of two) and requires every consumer to manually perform byte arithmetic to extract expression names. Additionally, reconstructing the formatted string requires the consumer to implement its own replacement loop using the byte offsets rather than calling a single library function.
+
+### Interpolation metadata object syntax
+
+Rather than overloading the parentheses-free calling convention, a new prefix syntax could produce an interpolation metadata object that is used with normal parenthesized function calls:
+
+```luau
+local name = "Alice"
+local msg = @`Hello {name}`
+-- msg is an object like: { template = "Hello {name}", values = {"Alice"}, expressions = {"name"} }
+
+log:Info(@`The double of {a} is {double(a)}`)
+db:Exec(@`SELECT * FROM users WHERE id = {userId}`)
+```
+
+The `@` prefix before an interpolated string would evaluate to a structured object containing the template, values, and parsed expression names. This object could be passed to any function using normal parenthesized call syntax, stored in variables, placed in data structures, etc.
+
+This approach avoids the learning-curve issue of parenthesized vs. non-parenthesized calls having different semantics for interpolated strings. It also makes the intent explicit at the call site. However, it introduces new syntax (`@` prefix) for a feature that is also achievable through the parentheses-free calling convention, and it loses the concise DSL aesthetic of `log `message`` in favor of `log(@`message`)`.
 
 ### Manual format string with curried values
 
@@ -317,14 +394,14 @@ This RFC automates the decomposition that developers would otherwise have to do 
 
 ### Expressions list instead of byte offsets
 
-Instead of byte offsets, the third argument could be a sequential table of expression source texts:
+Instead of core library functions, the compiler could pass expression source texts directly as a third argument:
 
 ```luau
 log:Info `Hello {name}`
--- Would pass: log:Info("Hello %*", {"Alice"}, {"name"})
+-- Would pass: log:Info("Hello {name}", {"Alice"}, {"name"})
 ```
 
-This is slightly more convenient for consumers who only need expression names, but requires the language specification to define normalization rules for source text (whitespace trimming, quote handling for literals, etc.). The byte-offset approach avoids this complexity by letting consumers extract whatever they need directly from the original template string.
+This avoids the double-parsing drawback of the core library function approach and is slightly more convenient for consumers who only need expression names. However, it requires the language specification to define normalization rules for source text (whitespace trimming, quote handling for literals, etc.) and adds a third argument to the calling convention. The core library function approach handles normalization in the library implementation without burdening the calling convention.
 
 ### Tagged interpolated strings (JavaScript-style)
 
@@ -342,7 +419,7 @@ tag `Hello {name}, you have {count} messages`
 -- Would call: tag({"Hello ", ", you have ", " messages"}, {name, count})
 ```
 
-This was considered and the proposed design shares the same spirit: decomposing the interpolated string into parts that don't require the consumer to parse Luau expressions. The proposed design differs in preserving the original template string (useful as an aggregation key) and providing byte offsets for flexible extraction of expression metadata.
+This was considered and the proposed design shares the same spirit: decomposing the interpolated string into parts that don't require the consumer to parse Luau expressions. The proposed design differs in preserving the original template string (useful as an aggregation key) and providing library functions for flexible extraction of expression metadata.
 
 ### Interpolation table with named keys
 

--- a/docs/syntax-interpolated-string-function-calls.md
+++ b/docs/syntax-interpolated-string-function-calls.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Allow calling functions with interpolated string literals without parentheses. The call is desugared into a function call with three arguments: a format string with `%*` placeholders, a table of the evaluated interpolation values, and a table of the original expression source texts. This enables domain-specific language patterns like structured logging, SQL escaping, and HTML templating.
+Allow calling functions with interpolated string literals without parentheses. The call is desugared into a function call with three arguments: the original template string (with interpolation expressions intact), a table of the evaluated values, and a table of byte-offset/length pairs locating each interpolation expression within the template. This enables domain-specific language patterns like structured logging, SQL escaping, and HTML templating.
 
 ## Motivation
 
@@ -26,7 +26,13 @@ This proposal lifts that restriction with semantics that decompose the interpola
 
 ### Structured logging
 
-The primary motivating use case is structured logging, where it is valuable to capture both the formatted message template and its interpolation values for machine processing:
+The primary motivating use case is structured logging. Production log consumption systems have two key requirements:
+
+1. **Human-readable template strings** for aggregation. Logs need to be grouped by message pattern so that operators can see, for example, "200 instances/minute of '{foo} occurred after {bar}'" rather than an opaque format string or fingerprint.
+
+2. **Key-value structured data** for search and filtering. Given a template like `{user.name} logged in from {ip}`, the consuming system needs both the expression names (`user.name`, `ip`) and their runtime values (`"Alice"`, `"10.0.0.1"`) to enable queries like "show me all logs where user.name = 'Alice'".
+
+This proposal satisfies both requirements. The template string is passed directly as the first argument, and the byte offsets allow consumers to extract expression names and associate them with values:
 
 ```luau
 local a = 1
@@ -34,12 +40,11 @@ local function double(x: number)
   return x * 2
 end
 
--- Desugars to `log:Info("The double of %* is %*", {a, double(a)}, {"a", "double(a)"})`
--- Note that the second argument evalutes to {1, 2} at runtime, but not at the desugaring step.
+-- Desugars to: log:Info("The double of {a} is {double(a)}", {a, double(a)}, {{15, 3}, {22, 11}})
 log:Info `The double of {a} is {double(a)}`
 ```
 
-The template string enables aggregating logs by message pattern (e.g. grouping all "The double of %* is %*" messages), while the values and expression names provide searchable structured data for platforms like Splunk, Datadog, or Elasticsearch.
+The template `"The double of {a} is {double(a)}"` serves directly as an aggregation key, and a consumer can extract the expression names `"a"` and `"double(a)"` via the byte offsets.
 
 Without this feature, developers must either manually construct all arguments (tedious and error-prone) or use a logging library that implements its own template parsing at runtime (duplicating language functionality).
 
@@ -53,7 +58,7 @@ local sqlite = require("luau_sqlite")
 local function takeUserInput(db: sqlite.DB, user: string, comment: string)
   -- Auto-escape inputs to guard against SQL injection
   db:Exec `INSERT INTO user_inputs (user, comment) VALUES ({user}, {comment})`
-  -- Desugars to: db:Exec("INSERT INTO user_inputs (user, comment) VALUES (%*, %*)", {user, comment}, {"user", "comment"})
+  -- Desugars to: db:Exec("INSERT INTO user_inputs (user, comment) VALUES ({user}, {comment})", {user, comment}, {{47, 6}, {55, 9}})
 end
 ```
 
@@ -67,7 +72,7 @@ local tmpl = require("luau_html_renderer")
 local function renderPage(r: tmpl.Renderer, userinput: string)
   -- Automatic XSS protection through escaping
   return tmpl.HTML `The user asked about {userinput}`
-  -- Desugars to: tmpl.HTML("The user asked about %*", {userinput}, {"userinput"})
+  -- Desugars to: tmpl.HTML("The user asked about {userinput}", {userinput}, {{22, 11}})
 end
 ```
 
@@ -86,23 +91,19 @@ args ::= '(' [explist] ')' | tableconstructor | LiteralString | stringinterp
 
 When a function is called with an interpolated string literal in this style, the compiler desugars the call into a function call with three arguments:
 
-1. **Format string**: The template with each `{expression}` replaced by `%*`, e.g. `"The double of %* is %*"`
-2. **Values table**: A sequential table of the interpolation values, e.g. `{a, double(a)}`
-3. **Expressions table**: A sequential table of the original expression source texts, e.g. `{"a", "double(a)"}`
+1. **Template string**: The original template with interpolation expressions intact, e.g. `"The double of {a} is {double(a)}"`
+2. **Values table**: A sequential table of the evaluated interpolation values, e.g. `{a, double(a)}`
+3. **Offsets table**: A sequential table of `{offset, length}` pairs, where each pair gives the 1-based byte offset and length of the corresponding `{expression}` span (including braces) within the template string
 
-The format string and expressions table are determined at compile time. The values table is evaluated at runtime.
+The template string and offsets table are determined at compile time. The values table is evaluated at runtime.
 
-Each entry in the expressions table is the verbatim source text between the `{` and `}` delimiters, with leading and trailing whitespace trimmed. Quoting style, internal spacing, and other formatting are preserved as written:
+A consumer can extract the expression text for the i-th interpolation using the offsets:
 
 ```luau
-log `{  user.name  }`
--- Expressions table: {"user.name"} (leading/trailing whitespace trimmed)
-
-log `{"Alice"}`
--- Expressions table: {"\"Alice\""} (source text preserved, including quotes)
-
-log `{ { ["foo"] = "bar" } }`
--- Expressions table: {"{ [\"foo\"] = \"bar\" }"} (trimmed, but internal formatting preserved)
+-- Extract {expr} including braces
+local span = string.sub(template, offsets[i][1], offsets[i][1] + offsets[i][2] - 1)
+-- Extract just the expression name (strip braces)
+local expr = string.sub(template, offsets[i][1] + 1, offsets[i][1] + offsets[i][2] - 2)
 ```
 
 For method calls (`:` syntax), `self` is passed first as usual, followed by these three arguments.
@@ -117,33 +118,33 @@ local user = {name = "Alice"}
 
 -- Simple identifier
 log:Info `Processing item {id}`
--- Desugars to: log:Info("Processing item %*", {42}, {"id"})
+-- Desugars to: log:Info("Processing item {id}", {42}, {{17, 4}})
 
 -- Member expression
 log:Info `User {user.name} logged in`
--- Desugars to: log:Info("User %* logged in", {"Alice"}, {"user.name"})
+-- Desugars to: log:Info("User {user.name} logged in", {"Alice"}, {{6, 11}})
 
 -- Multiple expressions
 log:Info `{user.name} is processing item {id}`
--- Desugars to: log:Info("%* is processing item %*", {"Alice", 42}, {"user.name", "id"})
+-- Desugars to: log:Info("{user.name} is processing item {id}", {"Alice", 42}, {{1, 11}, {33, 4}})
 ```
 
 ### No expression restrictions
 
-Unlike some alternative designs that use named keys for interpolated values, this design uses positional tables. This means **any expression valid in a regular interpolated string is also valid here**, including function and method calls:
+This design uses positional tables, so **any expression valid in a regular interpolated string is also valid here**, including function and method calls:
 
 ```luau
 -- Function calls are allowed
 log:Info `Result is {compute()}`
--- Desugars to: log:Info("Result is %*", {compute()}, {"compute()"})
+-- Desugars to: log:Info("Result is {compute()}", {compute()}, {{11, 11}})
 
 -- Method calls are allowed
 log:Info `Name is {user:getName()}`
--- Desugars to: log:Info("Name is %*", {user:getName()}, {"user:getName()"})
+-- Desugars to: log:Info("Name is {user:getName()}", {user:getName()}, {{9, 17}})
 
 -- Repeated expressions are fine (each is a separate positional entry)
 log:Info `{increment()} and then {increment()}`
--- Desugars to: log:Info("%* and then %*", {increment(), increment()}, {"increment()", "increment()"})
+-- Desugars to: log:Info("{increment()} and then {increment()}", {increment(), increment()}, {{1, 13}, {25, 13}})
 ```
 
 Since values are stored positionally rather than keyed by expression text, there is no ambiguity when the same expression appears multiple times or when expressions have side effects.
@@ -155,8 +156,8 @@ Functions that accept variadic arguments will receive the three desugared argume
 ```luau
 local name = "Alice"
 print `Hello {name}`
--- Desugars to: print("Hello %*", {"Alice"}, {"name"})
--- Output: Hello %* table: 0x... table: 0x...
+-- Desugars to: print("Hello {name}", {"Alice"}, {{7, 6}})
+-- Output: Hello {name} table: 0x... table: 0x...
 ```
 
 This is likely not the desired output. Developers wanting simple string interpolation should use parentheses:
@@ -184,18 +185,16 @@ Some use cases (e.g. structured logging) benefit from passing additional context
 ```luau
 -- log accepts the desugared interpolated string arguments and returns
 -- a function that accepts additional context
-function log(fmt, vals, exprs)
+function log(template, vals, offsets)
   return function(context)
-    -- Reconstruct the formatted message
-    local message = string.format(fmt, table.unpack(vals))
-    -- Reconstruct a human-readable template using the expression names
-    local wrapped = table.create(#exprs)
-    for i, expr in exprs do
-      wrapped[i] = "{" .. expr .. "}"
+    -- The template (e.g. "Hello {name}") is already a human-readable aggregation key.
+    -- Build the formatted message by replacing {expr} spans with values.
+    local message = template
+    for i = #offsets, 1, -1 do
+      local pos, len = offsets[i][1], offsets[i][2]
+      message = string.sub(message, 1, pos - 1) .. tostring(vals[i]) .. string.sub(message, pos + len)
     end
-    local template = string.format(fmt, table.unpack(wrapped))
-    -- template is now "Hello {name}" -- the original template string.
-    emit(message, template, vals, exprs, context)
+    emit(message, template, vals, context)
   end
 end
 
@@ -204,7 +203,7 @@ end
 -- with the context table
 log `Hello {name}` {userId = 12345, region = "us-east"}
 
--- Desugars to: log("Hello %*", {"Alice"}, {"name"})({userId = 12345, region = "us-east"})
+-- Desugars to: log("Hello {name}", {"Alice"}, {{7, 6}})({userId = 12345, region = "us-east"})
 ```
 
 This approach requires no special grammar support. It is a natural composition of a parentheses-free interpolated string call (which returns a function) and a parentheses-free table literal call on that returned function.
@@ -217,16 +216,21 @@ A `Message` wrapper type can bridge the gap between this calling convention and 
 local Message = {}
 Message.__index = Message
 
-function Message.new(fmt, vals, exprs)
+function Message.new(template, vals, offsets)
   return setmetatable({
-    fmt = fmt,
+    template = template,
     values = vals,
-    expressions = exprs,
+    offsets = offsets,
   }, Message)
 end
 
 function Message:__tostring()
-  return string.format(self.fmt, table.unpack(self.values))
+  local result = self.template
+  for i = #self.offsets, 1, -1 do
+    local pos, len = self.offsets[i][1], self.offsets[i][2]
+    result = string.sub(result, 1, pos - 1) .. tostring(self.values[i]) .. string.sub(result, pos + len)
+  end
+  return result
 end
 ```
 
@@ -245,7 +249,7 @@ Structured logging APIs can also inspect the Message's fields directly:
 
 ```luau
 function structured_log(msg: Message)
-  emit(tostring(msg), msg.fmt, msg.values, msg.expressions)
+  emit(tostring(msg), msg.template, msg.values, msg.offsets)
 end
 ```
 
@@ -262,7 +266,7 @@ Adding interpolated strings as a parentheses-free call argument adds complexity 
 Developers need to understand that interpolated string calls without parentheses behave differently from parenthesized calls. This could be confusing:
 
 ```luau
-log:Info `Hello {name}`        -- passes 3 arguments (format, values, expressions)
+log:Info `Hello {name}`        -- passes 3 arguments (template, values, offsets)
 log:Info(`Hello {name}`)       -- passes 1 argument (formatted string)
 ```
 
@@ -270,11 +274,46 @@ This distinction is intentional and valuable for DSL use cases, but documentatio
 
 ### Surprising behavior with existing functions
 
-Existing functions that are not designed for this calling convention will receive unexpected arguments if called without parentheses. For example, `print` and `warn` accept variadic arguments and would print the format string, values table, and expressions table alongside each other rather than producing a formatted message.
+Existing functions that are not designed for this calling convention will receive unexpected arguments if called without parentheses. For example, `print` and `warn` accept variadic arguments and would print the template string, values table, and offsets table alongside each other rather than producing a formatted message.
 
 Functions designed for parentheses-free interpolated string calls would need to be written (or updated, if possible) to accept the three-argument format. When an existing function cannot be updated in a non-breaking way (for example, because it accepts variadic arguments), a pattern such as the `Message` wrapper type described in the Design section can be used instead to bridge the gap.
 
 ## Alternatives
+
+### Manual format string with curried values
+
+As noted by reviewers, a similar pattern is already achievable without new syntax using currying with a format string and a values table:
+
+```luau
+local function Log(fmt: string)
+  return function(args: { any })
+    local message = string.format(fmt, table.unpack(args))
+    print("Log:", message, "Format:", fmt)
+  end
+end
+
+local user = "Bottersnike"
+Log "Hello, %*" { user }
+```
+
+While this works for simple cases, it has significant limitations:
+
+1. The developer must manually write the format string separately from the values, losing the ergonomic benefits of interpolated string syntax and introducing a risk of the two getting out of sync
+2. The format string uses `%*` placeholders rather than the original expression names, so it cannot serve as a human-readable aggregation key (e.g., `"Hello, %*"` vs. `"Hello, {user}"`)
+3. There is no way to recover expression names for structured key-value logging
+
+This RFC automates the decomposition that developers would otherwise have to do by hand, while preserving the original template and expression metadata.
+
+### Expressions list instead of byte offsets
+
+Instead of byte offsets, the third argument could be a sequential table of expression source texts:
+
+```luau
+log:Info `Hello {name}`
+-- Would pass: log:Info("Hello %*", {"Alice"}, {"name"})
+```
+
+This is slightly more convenient for consumers who only need expression names, but requires the language specification to define normalization rules for source text (whitespace trimming, quote handling for literals, etc.). The byte-offset approach avoids this complexity by letting consumers extract whatever they need directly from the original template string.
 
 ### Tagged interpolated strings (JavaScript-style)
 
@@ -292,11 +331,7 @@ tag `Hello {name}, you have {count} messages`
 -- Would call: tag({"Hello ", ", you have ", " messages"}, {name, count})
 ```
 
-This was considered and the proposed design shares the same spirit: decomposing the interpolated string into parts that don't require the consumer to parse Luau expressions. The proposed design differs in using a format string with `%*` placeholders instead of a string parts array, and in providing an additional expressions table with the source text of each interpolated expression. The format string approach:
-
-1. Provides a single template string usable as a log aggregation key or cache key
-2. Is more familiar to Luau developers accustomed to `string.format`-style patterns
-3. Includes expression metadata (source text) useful for debugging and structured logging
+This was considered and the proposed design shares the same spirit: decomposing the interpolated string into parts that don't require the consumer to parse Luau expressions. The proposed design differs in preserving the original template string (useful as an aggregation key) and providing byte offsets for flexible extraction of expression metadata.
 
 ### Interpolation table with named keys
 

--- a/docs/syntax-interpolated-string-function-calls.md
+++ b/docs/syntax-interpolated-string-function-calls.md
@@ -46,6 +46,17 @@ log:Info `The double of {a} is {double(a)}`
 
 The template `"The double of {a} is {double(a)}"` serves directly as an aggregation key, and a consumer can extract the expression names `"a"` and `"double(a)"` via the byte offsets.
 
+These template strings are substantially more useful than format strings with opaque `%*` placeholders. Compare these two log call sites:
+
+```luau
+log `{query} returned {result} in {duration}ms`
+log `{endpoint} returned {status} in {duration}ms`
+```
+
+With template strings, these aggregate separately, so operators can distinguish database queries from HTTP requests. With `%*` format strings, both produce `"%* returned %* in %*ms"` and would merge into a single bucket. Call stack metadata (e.g. fingerprints) could be used to disambiguate, but the resulting aggregation keys are opaque and require a source code lookup to interpret.
+
+Template strings also make aggregated log patterns self-documenting. An operator seeing a pattern like `"%*: %* %*:%* -> %*:%* proto=%* bytes=%*"` in a dashboard cannot map the first four `%*` to meaning without a source code lookup. The template `"{rule_id}: {action} {src_ip}:{src_port} -> {dst_ip}:{dst_port} proto={proto} bytes={bytes}"` is immediately interpretable.
+
 Without this feature, developers must either manually construct all arguments (tedious and error-prone) or use a logging library that implements its own template parsing at runtime (duplicating language functionality).
 
 ### SQL escaping


### PR DESCRIPTION
## Summary

Allow calling functions with interpolated strings without parentheses, enabling DSL patterns like structured logging, SQL escaping, and HTML templating. The call desugars into two arguments: the original template string (with interpolation expressions intact) and a table of evaluated values.

```luau
log:Info `Hello {name}`
-- Desugars to: log:Info(string.interpolatedstring.create({"Hello ", ""}, {name}))
```

Two new core library functions are also introduced:
* `string.interpolate` executes the default string interpolation algorithm for such a template string, and
* `string.interpolatedstring.create`, which creates a wrapping table and ascribes to it a metatable that provides a few useful operator overloads.

## Motivation

The [string interpolation RFC](https://github.com/luau-lang/rfcs/blob/master/docs/syntax-string-interpolation.md) noted the restriction on parentheses-free calls was "likely temporary while we work through string interpolation DSLs." This RFC proposes lifting that restriction with semantics designed for structured logging and similar use cases.

## Key design decisions

- Parentheses-free interpolated string calls desugar to an interpolated string object
- Any expression valid in a regular interpolated string is also valid here (no restrictions)
- Currying pattern enables passing additional context without grammar changes
