### PR TITLE
RFC: Unique types

### DIFF
--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -20,7 +20,7 @@ A structure that is an intersection between some type T and a unique type U will
 ---
 The proposed syntax to create a unique type is to define it using `unique type TypeName`, it does not have an = symbol after it because all unique types are are opaque unique types, they do not contain any additional information beyond that.
 
-The name `unique` was chosen as it clearly conveys that this specific type is unique and is not the same as any other type
+The name `unique` was chosen as it clearly conveys that this specific type is unique and is not the same as any other type.
 Unique types of the same name defined in different files will, of course, still be unique as their own "primitive" type, and cannot be cast to eachother.
 
 ### Behavior with intersections

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -6,7 +6,7 @@ This RFC proposes adding support for unique types to luau, which are a way to de
 
 ## Motivation
 ---
-Since Luau uses structural typing, there is no way to make a primitive distinct. If there are two types PlayerId and AssetId and they are both strings, the type checker allows a PlayerId to be passed into a function expecting AssetId because they are both just string.
+Since Luau uses structural typing, there is no way to make a primitive distinct. If there are two type aliases PlayerId and AssetId and they are both `string`s, the type checker allows a PlayerId to be passed into a function expecting AssetId because they are both just aliases to `string`.
 
 Current workarounds like tagging (string & { _tag: "PlayerId" }) are messy and confuse autocomplete.
 

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -197,7 +197,7 @@ Due to the nature of unique types, there would be no way to construct unique typ
 
 However, since you should be able to input unique types into type functions, or use it as an upvalue, the following are some semantic rules for unique `type` objects:
 
-- Using `type:__eq()` on an instantiated unique `type` object on any type other than itself or the type it was instantiated from should return `false` (for example, where T is instantiated from UniqueType and passed as a parameter, `T == UniqueType` -> `true`, `T == T` -> `true`, `UniqueType == types.number` -> `false`, `T == types.string` -> `false`).
+- Using `type:__eq()` on a unique `type` object on any type other than itself or the type it was instantiated from should return `false` (for example, where T is instantiated from UniqueType and passed as a parameter, `T == UniqueType` -> `true`, `T == T` -> `true`, `UniqueType == types.number` -> `false`, `T == types.string` -> `false`).
 - There should be a new valid string input to `type:is()`, which is `"unique"`. Illustrated in code:
   ```luau
   type function hi(T)
@@ -209,7 +209,7 @@ However, since you should be able to input unique types into type functions, or 
     return T
   end
   ```
-- Unique types that are passed into type functions should have a `.tag` property set to `"unique"` too.
+- Unique types that are used in type functions should have a `.tag` property set to `"unique"` too.
 - Implement a new method to `type`, which is `type:generics() -> {type}`. This will return the list of instantiated generic values bound to the unique type.
 - Implement a new method to `type`, which is `type:setgenerics({type}) -> ()`. This will set the list of instantiated generic values bound to the unique type. 
 - `type:is()` will work if you try to check the supertype of a unique type, so for example:

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -54,7 +54,7 @@ local moredata = getPlaceData(a) -- Again, doesnt work
 local moreadaatatata = getPlaceData(a :: PlaceId) -- Works!
 ```
 
-Unique types can be casted to other unique types, or other structural types provided the types are compatible in a structural manner. That is to say:
+Unique types can be casted to other structural types provided the types are compatible in a structural manner. That is to say:
 
 ```luau
 type Vec2: { x: number, y: number }

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -178,7 +178,7 @@ Due to the nature of unique types, there would be no way to construct unique typ
 
 However, since you should be able to input unique types into type functions, or use it as an upvalue, the following are some semantic rules for unique `type` objects:
 
-- Calling `type:__eq()` or using the `==` operator on a unique `type` object on any type other than itself should return `false`.
+- Using `type:__eq()` on an instantiated unique `type` object on any type other than itself or the type it was instantiated from should return `false` (for example, where T is instantiated from UniqueType and passed as a parameter, `T == UniqueType` -> `true`, `T == T` -> `true`, `UniqueType == types.number` -> `false`, `T == types.string` -> `false`).
 - There should be a new valid string input to `type:is()`, which is `"unique"`. Illustrated in code:
   ```luau
   type function hi(T)
@@ -191,6 +191,22 @@ However, since you should be able to input unique types into type functions, or 
   end
   ```
 - Unique types that are passed into type functions should have a `.tag` property set to `"unique"` too.
+- Implement a new method to `type`, which is `type:generics() -> {type}`. This will return the list of instantiated generic values bound to the unique type.
+- Implement a new method to `type`, which is `type:setgenerics({type}) -> ()`. This will set the list of instantiated generic values bound to the unique type. 
+- `type:is()` will work if you try to check the supertype of a unique type, so for example:
+    ```luau
+    type PlayerId<T>: T
+    
+    type function playerIdToString(t: type)
+        assert(t:is("number") and t == PlayerId)
+        local newid = PlayerId(types.string)
+        return newid
+    end
+
+    local a: PlayerId<number>
+    local b: playerIdToString<typeof(a)> = tostring(a)
+    ```
+- `type:issubtypeof(T)` should return true if T is defined as a supertype of the unique type, false if otherwise.
 
 # Drawbacks
 ---

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -20,9 +20,33 @@ The proposed syntax to create a unique type is to define it using `type TypeName
 
 A unique type is allowed to have other unique types as its supertype
 
-### Behavior with autocomplete
+### Operations & interface of the unique type
 
-The autocomplete of a unique type should inherit from its defined supertype, as the unique type is gauranteed to have everything that the supertype has.
+The operations & interface of a unique type inherit from its defined supertype, as the unique type is gauranteed to have everything that the supertype has.
+For example:
+
+```luau
+type Vector4: setmetatable<{x: number, y: number, z: number, w: number}, {
+  __add: (Vector4, Vector4) -> (Vector4)
+}>
+
+local function Vector4(x: number?, y: number?, z: number?, w: number?): Vector4
+
+local a = Vector4(1, 2, 3, 4)
+local b = Vector4(2, 3, 4, 5)
+
+print(a + b) -- Works
+```
+
+Or an example with primitives:
+```luau
+type PlaceId: string
+
+local id1: PlaceId = "1212"
+local id2: PlaceId = "32302309"
+
+local result = id1..id2 -- The type of result here would be string, because it takes the __concat operator overload raw from string, which is the supertype defined for it. This may be undesirable however
+```
 
 ### Casting semantics
 

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -236,6 +236,10 @@ However, since you should be able to input unique types into type functions, or 
 # Alternatives
 ---
 
+### The nominal typing rfc
+There is an alternative nominal typing rfc that proposes encapsulating structural types inside of nominal types instead:
+[#123](https://github.com/luau-lang/rfcs/pull/123)
+
 ### Just use tables
 My example of distinct UserId and AssetId types could instead be written as
 

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -192,6 +192,26 @@ Since it would be nice for unique types to be able to be used outside of the fil
 The way I propose would be to simply force the syntax of `export unique type TypeName` to be the way to export unique types, for example `unique export type TypeName` shouldn't work.
 This may be a bit verbose however it isn't any longer and is more clear and consistent with existing syntax (`export type function`) than any alternatives such as attributes or symbols.
 
+### Type function semantics
+
+Due to the nature of unique types, there would be no way to construct unique types in type functions.
+
+However, since you should be able to input unique types into type functions, or use it as an upvalue, the following are some semantic rules for unique `type` objects:
+
+- Calling `type:__eq()` or using the `==` operator on a unique `type` object on any type other than itself should return `false`.
+- There should be a new valid string input to `type:is()`, which is `"unique"`. Illustrated in code:
+  ```luau
+  type function hi(T)
+    if T:is("unique") then
+      print("t is unique!")
+    else
+      print("t is normal :(")
+    end
+    return T
+  end
+  ```
+- Unique types that are passed into type functions should have a `.tag` property set to `"unique"` too.
+
 # Drawbacks
 ---
 - **Verbose type signatures**: Types that compose unique types will have an ugly type signature (for example `_uniquetype & string`) which means that developers that want a nice clean identifier signature for their unique types (for example `PlayerId`) will not be able to achieve it without risking type safety by directly using unique types instead of composing them, as illustrated here:

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -144,7 +144,7 @@ end
 However, if a member of a unique type was to be refined like so:
 
 ```luau
-type Proxy: {inst: Instance?, metadata: {[string}: any}}
+type Proxy: {inst: Instance?, metadata: {[string]: any}}
 
 local function modify(p: Proxy)
     if p.inst then

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -152,6 +152,19 @@ local value = get(entA) -- string
 local value1 = get(entB) -- number
 ```
 
+Generic arguments can also be used to define the supertype, for example:
+
+```luau
+type UserId<ValueType = any>: ValueType
+
+local function getUserId(): UserId
+local function saveUserId(id: UserId<string>)
+
+local id: UserId<number> = getUserId()
+saveUserId(id) -- Does not work! number is not a subtype of string
+saveUserId(id :: UserId<string>) -- Does not work! number is not a subtype of string in the generics list
+```
+
 ### Type function semantics
 
 Due to the nature of unique types, there would be no way to construct unique types in type functions.

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -163,6 +163,7 @@ local function saveUserId(id: UserId<string>)
 local id: UserId<number> = getUserId()
 saveUserId(id) -- Does not work! number is not a subtype of string
 saveUserId(id :: UserId<string>) -- Does not work! number is not a subtype of string in the generics list
+saveUserId(tostring(id) :: UserId<string>) -- Works! The type signature for tostring is tostring(...any) -> string, and since we now have a string it's able to be converted into UserId<string>.
 ```
 
 ### Type function semantics

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -20,34 +20,6 @@ The proposed syntax to create a unique type is to define it using `type TypeName
 
 A unique type is allowed to have other unique types as its supertype
 
-### Operations & interface of the unique type
-
-The operations & interface of a unique type inherit from its defined supertype, as the unique type is gauranteed to have everything that the supertype has.
-For example:
-
-```luau
-type Vector4: setmetatable<{x: number, y: number, z: number, w: number}, {
-  __add: (Vector4, Vector4) -> (Vector4)
-}>
-
-local function Vector4(x: number?, y: number?, z: number?, w: number?): Vector4
-
-local a = Vector4(1, 2, 3, 4)
-local b = Vector4(2, 3, 4, 5)
-
-print(a + b) -- Works
-```
-
-Or an example with primitives:
-```luau
-type PlaceId: string
-
-local id1: PlaceId = "1212"
-local id2: PlaceId = "32302309"
-
-local result = id1..id2 -- The type of result here would be string, because it takes the __concat operator overload raw from string, which is the supertype defined for it. This may be undesirable however
-```
-
 ### Casting semantics
 
 When assigning a value to a variable, a cast will NOT be implicitly performed. An explicit cast must be done first, because unique types are different types from types such as literals and primitives.
@@ -90,6 +62,34 @@ local vec3_2 = vec2_1 :: Vec3 -- Doesnt work, "z" is missing from the type
 local vec3_3 = vec3_2 :: Vec2 -- Doesnt work, Vec3 cannot be cast into Vec2 despite the fact that Vec2 is a valid subtype of Vec3
 
 local vec2_3 = vec2_2 :: {x: number, y: number} -- This works because {x: number, y: number} is a subtype of {x: number, y: number} (itself)
+```
+
+### Operations & interface of a unique type
+
+The operations & interface of a unique type inherit from its defined supertype, as the unique type is gauranteed to have everything that the supertype has.
+For example:
+
+```luau
+type Vector4: setmetatable<{x: number, y: number, z: number, w: number}, {
+  __add: (Vector4, Vector4) -> (Vector4)
+}>
+
+local function Vector4(x: number?, y: number?, z: number?, w: number?): Vector4
+
+local a = Vector4(1, 2, 3, 4)
+local b = Vector4(2, 3, 4, 5)
+
+print(a + b) -- Works
+```
+
+Or an example with primitives:
+```luau
+type PlaceId: string
+
+local id1 = "1212" :: PlaceId
+local id2 = "32302309" :: PlaceId
+
+local result = id1..id2 -- The type of result here would be string, because it takes the __concat operator overload raw from string, which is the supertype defined for it. This may be undesirable however
 ```
 
 ### Behavior with intersections

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -185,6 +185,13 @@ local function handleEvent(event: Event)
 end
 ```
 
+### Exporting unique types
+
+Since it would be nice for unique types to be able to be used outside of the file it was declared in, we need to make the `export` keyword compatible with the `unique type TypeName` syntax.
+
+The way I propose would be to simply force the syntax of `export unique type TypeName` to be the way to export unique types, for example `unique export type TypeName` shouldn't work.
+This may be a bit verbose however it isn't any longer and is more clear and consistent with existing syntax (`export type function`) than any alternatives such as attributes or symbols.
+
 # Drawbacks
 ---
 - **Verbose type signatures**: Types that compose unique types will have an ugly type signature (for example `_uniquetype & string`) which means that developers that want a nice clean identifier signature for their unique types (for example `PlayerId`) will not be able to achieve it without risking type safety by directly using unique types instead of composing them, as illustrated here:

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -25,7 +25,9 @@ The autocomplete of a unique type should inherit from its defined supertype, as 
 
 ### Behavior with literals
 
-When assigning a literal value to a variable, a cast will NOT be implicitly performed. A unique type cannot be cast to another unique type, however can be cast to types it is subtype of (defined by the type expression after the : in the unique types declaration)
+When assigning a literal value to a variable, a cast will NOT be implicitly performed. For example, a number cannot be implicitly cast to a unique type that is a subtype of number, because a supertype cannot be implicitly cast into a subtype, and thus an explicit cast must be done first.
+
+A unique type cannot be cast to another unique type, however can be cast to types it is subtype of (defined by the type expression after the : in the unique types declaration)
 Illustrated in code:
 
 ```luau

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -37,7 +37,9 @@ type PlaceId: number
 local user1: UserId = 2  -- Doesnt work, must cast first
 local user2 = 2 :: UserId -- Works! UserId is a subtype of number and its being typecast
 local user3 = "2" :: UserId -- Doesnt work, string is not a supertype of UserId
-local user2: UserId = 12323 :: PlaceId -- Doesnt work, could not convert PlaceId into UserId
+local user4: UserId = 12323 :: PlaceId -- Doesnt work, could not convert PlaceId into UserId
+local user5 = 1234 :: PlaceId
+local user6 = user5 :: UserId -- Doesnt work, could not convert PlaceId into UserId
 
 local function getPlaceData(id: PlaceId)
 

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -23,9 +23,9 @@ The proposed syntax to create a unique type is to define it using `type TypeName
 
 The autocomplete of a unique type should inherit from its defined supertype, as the unique type is gauranteed to have everything that the supertype has.
 
-### Behavior with literals
+### Variable definition semantics
 
-When assigning a literal value to a variable, a cast will NOT be implicitly performed. For example, a number cannot be implicitly cast to a unique type that is a subtype of number, because a supertype cannot be implicitly cast into a subtype, and thus an explicit cast must be done first.
+When assigning a value to a variable, a cast will NOT be implicitly performed. An explicit cast must be done first, because unique types are different types from types such as literals and primitives.
 
 A unique type cannot be cast to another unique type, however can be cast to types it is subtype of (defined by the type expression after the : in the unique types declaration)
 Illustrated in code:
@@ -45,7 +45,13 @@ local function getPlaceData(id: PlaceId)
 
 local data = getPlaceData(1234) -- Doesnt work, must explicitly cast number to PlaceId
 local data = getPlaceData(1234 :: PlaceId) -- Works!
+
+local a = 10
+local moredata = getPlaceData(a) -- Again, doesnt work
+local moreadaatatata = getPlaceData(a :: PlaceId) -- Works!
 ```
+
+Some more examples involving more types of literals:
 
 ### Behavior with intersections
 
@@ -78,8 +84,6 @@ local vec2_2: Vec2 = vec3_1  -- Works, "x" and "y" are present, which is all tha
 local vec3_2: Vec3 = vec2_1  -- Doesnt work, "z" is missing from the type
 local vec3_3: Vec2 = vec3_2 -- Doesnt work, Vec3 cannot be cast into Vec2 despite the fact that Vec2 is a valid subtype of Vec3
 ```
-
-However, an annotation will NOT perform an implicit cast on the value. To assign a value to a variable of a unique type, you must typecast it first. This is so the programmer is required to pass explicit intent that they want this value to be of this unique type
 
 ### Refinement behavior
 

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -45,7 +45,7 @@ local data = getPlaceData(1234 :: PlaceId) -- Works!
 
 ### Behavior with intersections
 
-Using a unique type in an intersection would result in `*error type*`, as a unique type simply denotes a distinct type that is a subtype of something else, and intersecting with that shouldn't be allowed.
+Using a unique type in an intersection would result in `*error type*`, as a unique type simply denotes a distinct type that is a subtype of something else, and intersecting with that shouldn't be allowed because theres no actual "value" to intersect with here.
 
 ### Behavior with unions
 

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -58,11 +58,11 @@ Some more examples involving more types of literals:
 
 ### Behavior with intersections
 
-Using a unique type in an intersection would simply intersect with the subtype of the unique type, for example:
+Using a unique type in an intersection would simply intersect with the supertype of the unique type, for example:
 ```luau
 type Thing: {a: string}
 type ExtendedThing = Thing & {b: number} -- Aliases still work with unique types!
--- The subtype of ExtendedThing has been expanded, and since in the case of intersections, wider = subtype, that means ExtendedThing is now a subtype of {a: string} which is the supertype of Thing.
+-- The supertype of ExtendedThing has been expanded, and since in the case of intersections, wider = subtype, that means ExtendedThing is now a subtype of {a: string} which is the supertype of Thing.
 
 local thing = {a: string, b: number} :: ExpandedThing -- Works!
 local thing2 = thing :: Thing -- This works! Since thing is actually the same unique type, just with the expanded supertype of ExtendedThing, and ExtendedThing is a subtype of {a: string} which is the supertype of Thing, that means this cast is valid.

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -144,10 +144,14 @@ local function processItem(item: ItemId | ItemData)
         print("Item: " .. item.name)
     end
 end
+```
+
 Unique types work with discriminated unions:
-luauunique type EventType
-type ClickEvent = EventType & { kind: "click", x: number, y: number }
-type KeyEvent = EventType & { kind: "key", code: string }
+
+```luau
+unique type EventType
+  type ClickEvent = EventType & { kind: "click", x: number, y: number }
+  type KeyEvent = EventType & { kind: "key", code: string }
 
 type Event = ClickEvent | KeyEvent
 

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -58,7 +58,15 @@ Some more examples involving more types of literals:
 
 ### Behavior with intersections
 
-Using a unique type in an intersection would result in `*error type*`, as a unique type simply denotes a distinct type that is a subtype of something else, and intersecting with that shouldn't be allowed because theres no actual "value" to intersect with here.
+Using a unique type in an intersection would simply intersect with the subtype of the unique type, for example:
+```luau
+type Thing: {a: string}
+type ExtendedThing = Thing & {b: number} -- Aliases still work with unique types!
+-- The subtype of ExtendedThing has been expanded, and since in the case of intersections, wider = subtype, that means ExtendedThing is now a subtype of {a: string} which is the supertype of Thing.
+
+local thing = {a: string, b: number} :: ExpandedThing -- Works!
+local thing2 = thing :: Thing -- This works! Since thing is actually the same unique type, just with the expanded supertype of ExtendedThing, and ExtendedThing is a subtype of {a: string} which is the supertype of Thing, that means this cast is valid.
+```
 
 ### Behavior with unions
 
@@ -130,6 +138,18 @@ local function handleUEvent(event: UEvent)
     -- Due to this, this means that the "event" variable will have 0 autocomplete (opaque) because it's unclear which one it's supposed to be
     -- So here, no refinement occurs and event remains as UEvent
   end
+end
+```
+
+However, if a member of a unique type was to be refined like so:
+
+```luau
+type Proxy: {inst: Instance?, metadata: {[string}: any}}
+
+local function modify(p: Proxy)
+    if p.inst then
+        -- The supertype of p would be refined to Proxy & {inst: ~(false?) & Instance, metadata: {[string]: any}}, narrowing the type and becoming a subtype of the original supertype.
+    end
 end
 ```
 

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -26,7 +26,7 @@ A unique type is allowed to have other unique types as its supertype
 
 The autocomplete of a unique type should inherit from its defined supertype, as the unique type is gauranteed to have everything that the supertype has.
 
-### Variable definition semantics
+### Casting semantics
 
 When assigning a value to a variable, a cast will NOT be implicitly performed. An explicit cast must be done first, because unique types are different types from types such as literals and primitives.
 
@@ -54,7 +54,19 @@ local moredata = getPlaceData(a) -- Again, doesnt work
 local moreadaatatata = getPlaceData(a :: PlaceId) -- Works!
 ```
 
-Some more examples involving more types of literals:
+Unique types can be casted to other unique types, or other structural types provided the types are compatible in a structural manner. That is to say:
+
+```luau
+type Vec2: { x: number, y: number }
+type Vec3: { x: number, y: number, z: number }
+
+local vec2_1 = { x=1, y=1 }
+local vec3_1 = { x=1, y=1, z=2 }
+
+local vec2_2: Vec2 = vec3_1  -- Works, "x" and "y" are present, which is all that's required
+local vec3_2: Vec3 = vec2_1  -- Doesnt work, "z" is missing from the type
+local vec3_3: Vec2 = vec3_2 -- Doesnt work, Vec3 cannot be cast into Vec2 despite the fact that Vec2 is a valid subtype of Vec3
+```
 
 ### Behavior with intersections
 
@@ -80,21 +92,6 @@ local function getData(id: UserIdNumber | UserIdString) -- This makes sense, Use
 local function getDataStringy(id: string | UserIdString) -- This also makes sense, string | UserIdString reads as "A string, or UserIdString, a type that is a subtype of string".
 
 local data = getData(1234 :: UserIdNumber)
-```
-
-### Casting semantics
-Unique types can be casted to other unique types, or other structural types provided the types are compatible in a structural manner. That is to say:
-
-```luau
-type Vec2: { x: number, y: number }
-type Vec3: { x: number, y: number, z: number }
-
-local vec2_1 = { x=1, y=1 }
-local vec3_1 = { x=1, y=1, z=2 }
-
-local vec2_2: Vec2 = vec3_1  -- Works, "x" and "y" are present, which is all that's required
-local vec3_2: Vec3 = vec2_1  -- Doesnt work, "z" is missing from the type
-local vec3_3: Vec2 = vec3_2 -- Doesnt work, Vec3 cannot be cast into Vec2 despite the fact that Vec2 is a valid subtype of Vec3
 ```
 
 ### Refinement behavior

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -229,6 +229,8 @@ type PlayerId = _playerid & number -- Has type safety, but ugly type signature
 
 - **Complexity with multiple unique tags**: Code using multiple intersected unique types (e.g., `Validated & Sanitized & EventType & { ... }`) can become difficult to read and reason about, especially when determining which unique tags are preserved through refinement.
 
+- **No other language has done this**: The concept of a subset of nominal typing (which is what unique types are) being implemented as first-class syntax hasn't been done in other mainstream languages, which can hinder the adoption of this feature.
+
 # Alternatives
 ---
 

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -36,6 +36,11 @@ local user1: UserId = 2  -- Doesnt work, must cast first
 local user2 = 2 :: UserId -- Works! UserId is a subtype of number and its being typecast
 local user3 = "2" :: UserId -- Doesnt work, string is not a supertype of UserId
 local user2: UserId = 12323 :: PlaceId -- Doesnt work, could not convert PlaceId into UserId
+
+local function getPlaceData(id: PlaceId)
+
+local data = getPlaceData(1234) -- Doesnt work, must explicitly cast number to PlaceId
+local data = getPlaceData(1234 :: PlaceId) -- Works!
 ```
 
 ### Behavior with intersections

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -100,7 +100,7 @@ local b = Vector4(2, 3, 4, 5)
 print(a + b) -- Works, since we defined the supertype as a literal it's unecessary to replace anything inside it
 ```
 
-And in the case of primitive, aliased or other unique type supertype definitions, here for example, the function signature `string.sub(string, number?, number?)` would be replaced with `PlaceId.sub(PlaceId, number?, number?)` in thexe following ample:
+And in the case of primitive, aliased or other unique type supertype definitions, here for example, the function signature `string.sub(string, number?, number?)` would be replaced with `PlaceId.sub(PlaceId, number?, number?)` in the following examples:
 ```luau
 type PlaceId: string
 
@@ -111,7 +111,6 @@ local subbed = id1:sub(3, -1) -- This works because the string type in the 1st a
 local result = id1..id2 -- The type of result here would be PlaceId because the function signture "__concat: (string, string) -> string" would be replaced with "__concat: (PlaceId, PlaceId) -> PlaceId", this also means you cant concat a PlaceId with any ol' string
 ```
 
-More examples:
 ```luau
 type RayDirection: vector -- This is a primitive supertype, so any mentions of vector in its type signature should be replaced with RayDirection. The vector type itself does not have any methods, however it does have metamethods as operator overloads so that's where the type signature will be replaced.
 

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -20,6 +20,8 @@ A unique type will be able to be cast to its supertype, but not to other unique 
 ---
 The proposed syntax to create a unique type is to define it using `type TypeName: Supertype`, the unique type `TypeName` will be defined as having a supertype `Supertype`, defined after the colon. A unique type with no supertype is not allowed as that type would never exist and is "uninhabited".
 
+A unique type is allowed to have other unique types as its supertype
+
 ### Behavior with autocomplete
 
 The autocomplete of a unique type should inherit from its defined supertype, as the unique type is gauranteed to have everything that the supertype has.
@@ -66,9 +68,10 @@ Using a unique type in a union would work, illustrated in something like:
 type UserIdNumber: number
 type UserIdString: string
 
-local function getData(id: UserIdNumber | UserIdString) end
+local function getData(id: UserIdNumber | UserIdString) -- This makes sense, UserIdNumber | UserIdString reads as "UserIdNumber, a type that is a subtype of number, or UserIdString, a type that is a subtype of string".
+local function getDataStringy(id: string | UserIdString) -- This also makes sense, string | UserIdString reads as "A string, or UserIdString, a type that is a subtype of string".
 
-local data = getData(1234 :: UserIdNumber) -- This makes sense, UserIdNumber | UserIdString reads as "UserIdNumber, a type that is a subtype of number, or UserIdString, a type that is a subtype of string".
+local data = getData(1234 :: UserIdNumber)
 ```
 
 ### Casting semantics
@@ -142,15 +145,17 @@ An example of usage:
 
 ```luau
 type i53: number
-type Entity<T>: i53
+type Component<T>: i53
+type Entity: i53
 
-local entA = 102 :: Entity<string>
-local entB = 122 :: Entity<number>
+local function newEntity(): Entity
+local function newComponent<T>(): Component<T>
+local function get<T>(entity: Entity, component: Component<T>): T
 
-local function get<T>(ent: Entity<T>): T
+local entity = newEntity()
+local component = newComponent<<string>>()
 
-local value = get(entA) -- string
-local value1 = get(entB) -- number
+local value = get(entity, component) -- value is string!
 ```
 
 Generic arguments can also be used to define the supertype, for example:

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -2,9 +2,7 @@
 ---
 ## Summary
 ---
-This RFC proposes adding support for unique types to luau.
-
-Unique types are an extension to the type checker, and make no changes to runtime semantics.
+This RFC proposes adding support for unique types to luau, which are a way to define nominal types that are subtypes of a supertype, and are able to hold instantiated generic types as metadata.
 
 ## Motivation
 ---

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -13,8 +13,8 @@ Since Luau uses structural typing, there is no way to make a primitive distinct.
 Current workarounds like tagging (string & { _tag: "PlayerId" }) are messy and confuse autocomplete.
 
 Unique types solve this by being able to be composed with existing types to make them completely unique, kind of like a tag.
-This relies on the behavior of intersections in that an intersection T can only be cast into another intersection U if T is the same/is a subtype of U
-A structure that is an intersection between some type T and a unique type U will not be able to be cast into another structure that is an intersection between the same type T and another unique type V
+This relies on the behavior of intersections in that an intersection T can only be cast into another intersection U if T is the same/is a subtype of U.
+A structure that is an intersection between some type T and a unique type U will not be able to be cast into another structure that is an intersection between the same type T and another unique type V.
 
 ## Design
 ---

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -54,7 +54,7 @@ local moredata = getPlaceData(a) -- Again, doesnt work
 local moreadaatatata = getPlaceData(a :: PlaceId) -- Works!
 ```
 
-Unique types can be casted to other structural types provided the types are compatible in a structural manner. That is to say:
+Unique types can be casted to other structural types provided the types are compatible in a structural manner and vice versa. That is to say:
 
 ```luau
 type Vec2: { x: number, y: number }
@@ -63,9 +63,11 @@ type Vec3: { x: number, y: number, z: number }
 local vec2_1 = { x=1, y=1 }
 local vec3_1 = { x=1, y=1, z=2 }
 
-local vec2_2: Vec2 = vec3_1  -- Works, "x" and "y" are present, which is all that's required
-local vec3_2: Vec3 = vec2_1  -- Doesnt work, "z" is missing from the type
-local vec3_3: Vec2 = vec3_2 -- Doesnt work, Vec3 cannot be cast into Vec2 despite the fact that Vec2 is a valid subtype of Vec3
+local vec2_2 = vec3_1 :: Vec2  -- Works, "x" and "y" are present, which is all that's required
+local vec3_2 = vec2_1 :: Vec3 -- Doesnt work, "z" is missing from the type
+local vec3_3 = vec3_2 :: Vec2 -- Doesnt work, Vec3 cannot be cast into Vec2 despite the fact that Vec2 is a valid subtype of Vec3
+
+local vec2_3 = vec2_2 :: {x: number, y: number} -- This works because {x: number, y: number} is a subtype of {x: number, y: number} (itself)
 ```
 
 ### Behavior with intersections

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -239,6 +239,8 @@ However, since you should be able to input unique types into type functions, or 
 There is an alternative nominal typing rfc that proposes encapsulating structural types inside of nominal types instead:
 [#123](https://github.com/luau-lang/rfcs/pull/123)
 
+The way this alternative rfc implements nominal types means that you aren't able to do operations such as multiplication on a `type UserId: number` type that results in a `number` type instead of another `UserId` type (desired) by making nominal types completely opaque when it is encapsulating a primitive type, unlike what this rfc proposes (since it relies on subtyping, any operations such as number + number -> number will be passed onto a unique type that uses it as its supertype even though the types are different from it.)
+
 ### Just use tables
 My example of distinct UserId and AssetId types could instead be written as
 

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -12,7 +12,8 @@ Since Luau uses structural typing, there is no way to make a primitive distinct.
 
 Current workarounds like tagging (string & { _tag: "PlayerId" }) are messy and confuse autocomplete.
 
-Unique types solve this by being able to be created with a supertype, giving them additional type information aside from being completely unique.
+Unique types solve this by being completely unique from any other type, therefor allowing programmers to bar casts between different unique types.
+A supertype and a list of generics can be assigned to a unique type to alter its subtyping behavior, making it easier to inter-operate between unique types and normal Luau structural types.
 A unique type will be able to be cast to its supertype, but not to other unique types or types that are not its supertype.
 
 ## Design

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -1,0 +1,227 @@
+# Unique Types
+---
+## Summary
+---
+This RFC proposes adding support for unique types to luau.
+
+Unique types are an extension to the type checker, and make no changes to runtime semantics.
+
+## Motivation
+---
+Since Luau uses structural typing, there is no way to make a primitive distinct. If there are two types PlayerId and AssetId and they are both strings, the type checker allows a PlayerId to be passed into a function expecting AssetId because they are both just string.
+
+Current workarounds like tagging (string & { _tag: "PlayerId" }) are messy and confuse autocomplete.
+
+Unique types solve this by being able to be composed with existing types to make them completely unique, kind of like a tag.
+This relies on the behavior of intersections in that an intersection T can only be cast into another intersection U if T is the same/is a subtype of U
+A structure that is an intersection between some type T and a unique type U will not be able to be cast into another structure that is an intersection between the same type T and another unique type V
+
+## Design
+---
+The proposed syntax to create a unique type is to define it using `unique type TypeName`, it does not have an = symbol after it because all unique types are are opaque unique types, they do not contain any additional information beyond that.
+
+The name `unique` was chosen as it clearly conveys that this specific type is unique and is not the same as any other type
+Unique types of the same name defined in different files will, of course, still be unique as their own "primitive" type, and cannot be cast to eachother.
+
+### Behavior with intersections
+
+Since unique types simply act as a unique opaque type, this means intersecting them is quite trivial and isn't much different from intersecting other primitive types such as `unknown`.
+
+### Behavior with literals
+
+When assigning a literal value to a variable, a cast will not be implicitly performed. It is expected that unique types will almost exclusively be generated within APIs, rather than written as literals.
+Illustrated in code:
+
+```luau
+unique type _useridtag
+type UserId = _useridtag & number
+
+local user1: UserId = 1  -- doesnt work, error
+local user2: UserId = 2 :: UserId  -- works!
+```
+
+It's important to note that the only reason this works is because unique types are opaque, and should work similarly to `unknown` wherein it'll "inherit" anything it's composed with
+
+### Casting semantics
+Unique types can be casted to other unique types, or other structural types provided the types are compatible in a structural manner. That is to say:
+
+```luau
+unique type Vector
+  type Vec2 = Vector & { x: number, y: number }
+  type Vec3 = Vector & { x: number, y: number, z: number }
+
+local vec2_1 = { x=1, y=1 } :: Vec2
+local vec3_1 = { x=1, y=1, z=2 } :: Vec3
+
+local vec2_2: Vec2 = vec3_1 :: Vec2  -- Works, "x" and "y" are present, which is all that's required
+local vec3_2: Vec3 = vec2_1 :: Vec3  -- Doesnt work, "z" is missing from the type
+```
+
+Again, it's important to note that the only reason this works is because unique types are opaque, and should work similarly to `unknown` wherein it'll "inherit" anything it's composed with
+
+### Enum-like behavior
+
+Because unique types are used as tags within intersections, this means you can get behavior similar to enums
+
+```luau
+unique type SomethingType
+  type Item = SomethingType & "Item"
+  type Weapon = SomethingType & "Weapon"
+
+local function getSomething(ty: SomethingType)
+
+getSomething("Weapon") -- type error: expected SomethingType, got "Weapon"
+getSomething("Weapon" :: Item) -- errors, could not convert "Weapon" into "Item"
+getSomething("Item" :: Item) -- works!
+getSomething("Weapon" :: Weapon) -- works!
+```
+
+### Mutually inclusive types
+
+A unique type can be composed within multiple type definitions to create mutually inclusive types which can only be cast to eachother or the tag but nothing else
+
+```luau
+unique type _coordtag
+  type CoordX = _coordtag & number
+  type CoordY = _coordtag & number
+  type CoordZ = _coordtag & number
+
+-- These can all be converted to each other
+local function swapAxes(x: CoordX, y: CoordY): (CoordY, CoordX)
+    return x :: CoordY, y :: CoordX
+end
+
+local function promoteToZ(x: CoordX): CoordZ
+    return x :: CoordZ
+end
+
+local x: CoordX = 10 :: CoordX
+local y: CoordY = 20 :: CoordY
+
+local newY, newX = swapAxes(x, y)  -- Valid
+local z: CoordZ = promoteToZ(x)    -- Valid
+
+-- But they're still isolated from regular numbers
+local regular: number = x  -- error: CoordX is not assignable to number
+
+-- And from other unique type families
+unique type _othertag
+type OtherId = _othertag & number
+local other: OtherId = x  -- error: Different unique tags
+```
+
+### Operations on unique types
+
+Since unique types themselves act like `unknown`, this means any sort of operations on a unique type itself will error and is invalid.
+However, if you compose a unique type, it'll have all the operations of the types you're composing it with.
+
+```luau
+unique type T
+type U = T & string
+
+local t: T
+local u: U
+
+print(t .. "hi") -- doesnt work, t doesnt have __concat
+print(u .. "hi") -- Works, type "string" does have __concat
+```
+
+### Refinement behavior
+
+Unique types can be refined through type guards and pattern matching based on their underlying structural types.
+
+```luau
+unique type _itemtag
+  type ItemId = _itemtag & string
+  type ItemData = _itemtag & { id: string, name: string }
+
+local function processItem(item: ItemId | ItemData)
+    if type(item) == "string" then
+        -- item is refined to ItemId
+        print("Item ID: " .. item)
+    else
+        -- item is refined to ItemData
+        print("Item: " .. item.name)
+    end
+end
+Unique types work with discriminated unions:
+luauunique type EventType
+type ClickEvent = EventType & { kind: "click", x: number, y: number }
+type KeyEvent = EventType & { kind: "key", code: string }
+
+type Event = ClickEvent | KeyEvent
+
+local function handleEvent(event: Event)
+    if event.kind == "click" then
+        -- event is refined to ClickEvent
+        print("Click at", event.x, event.y)
+    end
+end
+```
+
+When multiple unique types are intersected in a discriminated union, refinement preserves only the unique types that are compatible with all variants in the refined branch:
+
+```luau
+unique type Validated
+unique type Sanitized
+unique type EventType
+
+type ValidatedClick = Validated & EventType & { kind: "click", x: number }
+type SanitizedKey = Sanitized & EventType & { kind: "key", code: string }
+type ValidatedAndSanitizedScroll = Validated & Sanitized & EventType & { kind: "scroll", delta: number }
+
+type Event = ValidatedClick | SanitizedKey | ValidatedAndSanitizedScroll
+
+local function handleEvent(event: Event)
+    if event.kind == "click" or event.kind == "scroll" then
+        -- event is refined to: Validated & EventType & (ClickEvent | ScrollEvent)
+        -- Sanitized is discarded because ValidatedClick doesn't have it
+        processValidated(event)  -- Works: both variants have Validated
+    end
+end
+```
+
+# Drawbacks
+---
+- **Verbose type signatures**: Types that compose unique types will have an ugly type signature (for example `_uniquetype & string`) which means that developers that want a nice clean identifier signature for their unique types (for example `PlayerId`) will not be able to achieve it without risking type safety by directly using unique types instead of composing them, as illustrated here:
+```luau
+unique type PlayerId -- No type safety, but identifier type signature (signature is just the name which is PlayerId)
+unique type _playerid
+type PlayerId = _playerid & number -- Has type safety, but ugly type signature
+```
+
+- **Naming convention burden**: The recommended pattern of using a private unique type tag (e.g., `_playerid`) composed into a public type alias (e.g., `PlayerId`) creates a burden where developers must choose naming conventions for their tags. This could lead to inconsistency across codebases.
+
+- **Migration complexity**: Existing codebases that have string or number types for IDs will need explicit casts everywhere to convert to unique types, which could be a significant migration effort for large projects.
+
+- **Error message clarity**: Type errors involving unique types may be confusing, especially when the error shows the full intersection type (e.g., `_playerid & number`) rather than the friendly alias (`PlayerId`). This could make debugging harder for developers unfamiliar with unique types.
+
+- **Complexity with multiple unique tags**: Code using multiple intersected unique types (e.g., `Validated & Sanitized & EventType & { ... }`) can become difficult to read and reason about, especially when determining which unique tags are preserved through refinement.
+
+# Alternatives
+---
+
+### Just use tables
+My example of distinct UserId and AssetId types could instead be written as
+
+```luau
+type UserId = { userId: number }
+type AssetId = { assetId: number }
+```
+
+This works in the current system and makes these types incompatible. For the vectors example, the following snippet would produce the required incompatible types:
+
+```luau
+type Vec2 = { x: number, y: number, __isVec2: number }
+type Vec3 = { x: number, y: number, z: number, __isVec3: number }
+```
+
+A helper type could be used to perform this automatically, such as the following:
+
+```luau
+type Tagged<T, Tag> = T & { __tag: Tag }
+type UserId = Tagged<number, "UserId">
+type AssetId = Tagged<number, "AssetId">
+```
+
+In all of these cases, the types are no longer zero-cost at runtime, and in the cases where casting between "nominal" types is desired, it also incurs a runtime cost. The Tagged option does allow runtime introspection, however nothing in this RFC would disallow use of that existing pattern when desired.

--- a/docs/unique-types.md
+++ b/docs/unique-types.md
@@ -81,8 +81,8 @@ Unique types can be casted to other unique types, or other structural types prov
 type Vec2: { x: number, y: number }
 type Vec3: { x: number, y: number, z: number }
 
-local vec2_1 = { x=1, y=1 } :: Vec2
-local vec3_1 = { x=1, y=1, z=2 } :: Vec3
+local vec2_1 = { x=1, y=1 }
+local vec3_1 = { x=1, y=1, z=2 }
 
 local vec2_2: Vec2 = vec3_1  -- Works, "x" and "y" are present, which is all that's required
 local vec3_2: Vec3 = vec2_1  -- Doesnt work, "z" is missing from the type


### PR DESCRIPTION
[Rendered](https://github.com/athar-adv/unique-types/blob/master/docs/unique-types.md)

Introduces the syntax `unique type TypeName` to define unique opaque types