### PR TITLE
Type only imports for Luau

### DIFF
--- a/docs/type-only-importing.md
+++ b/docs/type-only-importing.md
@@ -106,4 +106,4 @@ For the case of extending the functionality of `require`:
 - No longer a function.
 
 ## Alternatives
-Use a header file for type definitions. Although, this scales poorly and can become cumbersome in larger projects.
+Use a header file for type definitions. Although, this scales poorly and can become cumbersome in larger projects. The current workarounds do not meaningfully solve the cyclic dependency problem, either.

--- a/docs/type-only-importing.md
+++ b/docs/type-only-importing.md
@@ -23,7 +23,7 @@ local function createMouse(Computer: Computer.Computer)
   return setmetatable({Computer = Computer}, Mouse):: Mouse
 end
 ```
-It becomes clear that retaining intellisense in this situation is impossible, since there is a cyclic dependency between `Computer` and `Mouse`. The logical next step would be to create a third container storing the `Computer` type, of which both `Computer` and `Mouse` require from it:
+Here, a cyclic dependency between `Computer` and `Mouse` makes retaining intellisense impossible. A popular workaround is introducing a third module solely for type definitions; essentially, a header file:
 ```lua
 -->> computer
 local Mouse = require(script.Mouse)
@@ -41,9 +41,9 @@ local function createMouse(Computer: __types.Computer)
   return setmetatable({Computer = Computer}, Mouse):: __types.Mouse
 end
 ```
-This works, and intellisense is restored. Unfortunately, this can become very cumbersome very quickly, especially if `Computer` also depends on other user-generated types, which may or may not generate their own cyclic dependencies. Basically, the current type importing state of Luau is a clear limiting factor when considering pratices like dependency injection.
+While this restores intellisense, it becomes cumbersome as more types and dependencies are added. The header file method works very well for types that can be created without the importing of external types, or put simply, a user-defined type that doesn't depend on other user-defined types.
 
-The above problem can easily be solved if code can directly import types, removing the need to depend on the module containing the types.
+An arguably more elegant solution is to allow code to directly import types, avoiding runtime dependencies:
 ```lua
 -->> computer
 local Mouse = require(script.Mouse)

--- a/docs/type-only-importing.md
+++ b/docs/type-only-importing.md
@@ -2,11 +2,11 @@
 
 ## Summary
 
-Add type-only imports to Luau, allowing code to import types without creating a runtime dependency. This enables support for importing interfaces, type aliases, and dependency injection.
+Add type-only importing to Luau, allowing code to import types without creating a runtime dependency.
 
 ## Motivation
 
-Assume the creation of a `Computer` and `Mouse` class. Computer uses `Mouse` as a component, and `Keyboard` requires `Computer` as an argument. Typically, the first instinct is to create something like:
+Assume the creation of a `Computer` and `Mouse` class. Computer uses `Mouse` as a component, and `Keyboard` requires `Computer` as an argument. Typically, the first instinct is to use dependency injection:
 ```lua
 -->> computer
 local Mouse = require(script.Mouse)
@@ -23,7 +23,7 @@ local function createMouse(Computer: Computer.Computer)
   return setmetatable({Computer = Computer}, Mouse):: Mouse
 end
 ```
-However, it becomes clear that this is impossible, since this causes a cyclic dependency between `Computer` and `Mouse`. The logical next step would be to create a third container storing the `Computer` type, of which both `Computer` and `Mouse` require from it:
+It becomes clear that retaining intellisense in this situation is impossible, since there is a cyclic dependency between `Computer` and `Mouse`. The logical next step would be to create a third container storing the `Computer` type, of which both `Computer` and `Mouse` require from it:
 ```lua
 -->> computer
 local Mouse = require(script.Mouse)
@@ -41,8 +41,7 @@ local function createMouse(Computer: __types.Computer)
   return setmetatable({Computer = Computer}, Mouse):: __types.Mouse
 end
 ```
-This works, but can become very cumbersome very quickly, especially if `Computer` also depends on other user-generated types, which may or may not generate their own cyclic dependencies.
-Reason being, the current type importing state of Luau is a clear limiting factor when considering pratices like dependency injection.
+This works, and intellisense is restored. Unfortunately, this can become very cumbersome very quickly, especially if `Computer` also depends on other user-generated types, which may or may not generate their own cyclic dependencies. Basically, the current type importing state of Luau is a clear limiting factor when considering pratices like dependency injection.
 
 The above problem can easily be solved if code can directly import types, removing the need to depend on the module containing the types.
 ```lua

--- a/docs/type-only-importing.md
+++ b/docs/type-only-importing.md
@@ -1,0 +1,91 @@
+# Type-only imports
+
+## Summary
+
+Add type-only imports to Luau, allowing code to import types without creating a runtime dependency. This enables support for importing interfaces, type aliases, and dependency injection.
+
+## Motivation
+
+Assume the creation of a `Computer` and `Mouse` class. Computer uses `Mouse` as a component, and `Keyboard` requires `Computer` as an argument. Typically, the first instinct is to create something like:
+```lua
+-->> computer
+local Mouse = require(script.Mouse)
+local function createComputer()
+  local self = setmetatable({}, Computer):: Computer
+  self.Mouse = Mouse.new(self)
+  return self
+end
+```
+```lua
+-->> mouse
+local Computer = require(script.Parent)
+local function createMouse(Computer: Computer.Computer)
+  return setmetatable({Computer = Computer}, Mouse):: Mouse
+end
+```
+However, it becomes clear that this is impossible, since this causes a cyclic dependency between `Computer` and `Mouse`. The logical next step would be to create a third container storing the `Computer` type, of which both `Computer` and `Mouse` require from it:
+```lua
+-->> computer
+local Mouse = require(script.Mouse)
+local __types = require(script.__types)
+local function createComputer()
+  local self = setmetatable({}, Computer):: __types.Computer
+  self.Mouse = Mouse.new(self)
+  return self
+end
+```
+```lua
+-->> mouse
+local __types = require(script.__types)
+local function createMouse(Computer: __types.Computer)
+  return setmetatable({Computer = Computer}, Mouse):: __types.Mouse
+end
+```
+This works, but can become very cumbersome very quickly, especially if `Computer` also depends on other user-generated types, which may or may not generate their own cyclic dependencies.
+Reason being, the current type importing state of Luau is a clear limiting factor when considering pratices like dependency injection.
+
+The above problem can easily be solved if code can directly import types, removing the need to depend on the module containing the types.
+```lua
+-->> computer
+local Mouse = require(script.Mouse)
+local function createComputer()
+  local self = setmetatable({}, Computer):: Computer
+  self.Mouse = Mouse.new(self)
+  return self
+end
+```
+```lua
+-->> mouse
+type Computer = typeget(script.Parent) --> no cylic dependency
+local function createMouse(Computer: Computer) --> intellisense on "Computer" remains
+  return setmetatable({Computer = Computer}, Mouse):: Mouse
+end
+```
+
+## Design
+
+Preferably, the desgin should adhere to the general appearance of Luau.
+Here are two proposed syntaxes:
+```lua
+type Apple, Banana = typeget(script.Fruits)
+type { Apple, Banana } = typeget(script.Fruits)
+```
+`type Apple, Banana = typeget(script.Fruits)` is more vanilla to Luau, but `type { Apple, Banana } = typeget(script.Fruits)` makes more semantic sense since type importing is unordered and named.
+
+Optionally, inline type extraction:
+```lua
+type User = require("./UserRepository").User
+```
+
+This feature incidentlly also alleviates Luau's wierd `ModuleName.ModuleType` syntax.
+
+Semantics:
+- Type-only imports are erased at runtime (or used for optimization).
+- No Lua code is emitted, so no runtime require happens.
+- Regular type imports directly from other code continue to behave as usual.
+
+## Drawbacks
+More keywords. Possible confusion with type extraction via `require`. `require` essentially becomes a `typeget` and a code emitter combined.
+
+## Alternatives
+As aforementioned, an alternative could be a third, intermediary module. But as explained, could quickly become cumbersome.

--- a/docs/type-only-importing.md
+++ b/docs/type-only-importing.md
@@ -63,7 +63,7 @@ end
 
 ## Design
 
-Preferably, the desgin should adhere to the general appearance of Luau.
+Preferably, the design should adhere to the general appearance of Luau.
 Here are two proposed syntaxes:
 ```lua
 type Apple, Banana = typeget(script.Fruits)

--- a/docs/type-only-importing.md
+++ b/docs/type-only-importing.md
@@ -73,18 +73,37 @@ type { Apple, Banana } = typeget(script.Fruits)
 
 Optionally, inline type extraction:
 ```lua
-type User = require("./UserRepository").User
+type User = typeget("./UserRepository").User
 ```
 
-This feature incidentlly also alleviates Luau's wierd `ModuleName.ModuleType` syntax.
+Alternatively, extend the behavior of `require` to act differently when expecting a type vs. dependency. Using the examples above:
+```lua
+-->> this
+type Apple, Banana = require(script.Fruits)
+
+-->> or this
+type { Apple, Banana } = require(script.Fruits)
+
+-->> and/or this
+type Apple = require(script.Fruits).Apple
+```
+
+This feature incidentlly alleviates Luau's wierd `ModuleName.ModuleType` syntax.
 
 Semantics:
 - Type-only imports are erased at runtime (or used for optimization).
-- No Lua code is emitted, so no runtime require happens.
+- No Luau code is emitted, so no runtime require happens.
 - Regular type imports directly from other code continue to behave as usual.
 
 ## Drawbacks
-More keywords. Possible confusion with type extraction via `require`. `require` essentially becomes a `typeget` and a code emitter combined.
+For the case of `typeget`:
+- More keywords.
+- Possible confusion with type extraction via `require`. `require` essentially becomes a `typeget` and a code emitter combined.
+
+For the case of extending the functionality of `require`:
+- Slightly more ambiguous functionality.
+- Code importing `require` and type importing `require` may not be immediately differentiable at a glance.
+- No longer a function.
 
 ## Alternatives
-As aforementioned, an alternative could be a third, intermediary module. But as explained, could quickly become cumbersome.
+Use a header file for type definitions. Although, this scales poorly and can become cumbersome in larger projects.


### PR DESCRIPTION
[Rendered](https://github.com/VegetationBush/rfcs/blob/VegetationBush-type-only-imports/docs/type-only-importing.md)

Implements a type-only import for Luau similar to that of TypeScript. This feature aims to introduce type extraction without runtime imports.