### PR TITLE
Mutable before return Export-by-Value Semantics

### DIFF
--- a/docs/export-keyword.md
+++ b/docs/export-keyword.md
@@ -1,7 +1,7 @@
 # Export by Value
 
 ## Summary
-Extend the `export` keyword to support variables and functions as syntax sugar for constructing a table and returning it from a module.
+Extend the `export` keyword to support variables and functions as syntax sugar for constructing a table and returning it from the module.
 
 ## Motivation
 Today, type aliases are able to be exported from a module using the `export` keyword.
@@ -14,12 +14,10 @@ However, this mechanism is currently only supported by types.
 
 Extending  `export`  to also support variable and function declarations would provide a consistent way for users to expose a stable API from modules.
 
-Furthermore, introducing a language-level concept of exporting opens the door to many optimizations not currently possible with dynamic module returns, such as cross-module inlining and constant-folding.
+Furthermore, introducing a language-level concept of exporting opens the door to many optimizations not currently possible with dynamic module returns, such as cross-module inlining and constant folding.
 
 ## Design
 The `export` contextual keyword will now be allowed anywhere before variable and function declarations at the top level of a module, including `local`, `const` and `function` declarations.
-
-Exporting declarations that are in nested `do end` blocks under the top scope are also permitted. Attempting to export a declaration outside the module scope will result in a parse error.
 
 Exported variables will count towards the local variable limit, as they can be optimized into locals by the compiler.
 
@@ -30,16 +28,6 @@ export const TAU = math.pi * 2
 export function init() -- exported functions are always const
 	-- TODO
 end
-
-do
-	local counter = 0
-	
-	export function increment(): number
-		counter += 1
-		return counter
-	end
-end
--- counter and increment not visible here
 
 if foo then
 	export local bar = 1 -- not allowed, syntax error
@@ -55,13 +43,11 @@ export local d -- same as export d = nil
 export const MAX_ITEMS = 10 -- cannot be reassigned
 ```
 
-Exporting a variable with the same identifier twice is a parse error, regardless of the scope it was defined in.
+Exporting a variable with the same identifier twice is a parse error.
 
 ```luau
 export local foo = 1
-do
-	export local foo = 2 -- syntax error
-end
+export local foo = 2 -- syntax error
 ```
 
 However, exporting a variable with the same identifier as another non-exported variable is allowed, following conventional lexical scoping and shadowing rules.
@@ -83,7 +69,7 @@ animal = "bird"
 print(animal) -- bird
 ```
 
-Exported function declarations are also always treated as const, as reassigning function declarations is usually a mistake.
+Exported function declarations are also always treated as const, as reassigning function declarations is unidiomatic and typically a mistake.
 
 ```luau
 export function f() end
@@ -91,7 +77,7 @@ f = 1 -- illegal
 ```
 
 ### Desugared Form
-Exporting variables desugars into assigning keys to a table that is then frozen and returned once the module scope ends.
+Exporting variables desugars into assigning keys to a table that is then frozen and returned once the module scope ends. Desugared examples are purely illustrative, as the compiler is free to optimize and restructure table construction internally.
 
 ```luau
 export local a = 1
@@ -112,7 +98,7 @@ if math.random(0, 1) == 1 then
 end
 
 export local f, g
-function f()
+function f() -- same as f = function() ...
 	g()
 end
 function g()
@@ -228,26 +214,26 @@ print(TAU)
 return table.freeze({TAU = TAU})
 ```
 
-Furthermore, first-class exports allow for the compiler to assume exported variables are never reassigned after module return, unlocking the ability to bring constant-folding and inlining across module boundaries.
+Furthermore, first-class exports allow for the compiler to assume exported variables are never reassigned after module return, unlocking the ability to bring constant folding and inlining across module boundaries.
 
 ## Drawbacks
 
-This increases compiler complexity in terms of tracking exported declarations and converting them into table assignments.
+This increases compiler complexity in terms of tracking exported declarations and converting them into table assignments. It also requires the parser to track export and return statements to ensure that the two are not mixed.
 
-Allowing reassignment of exported keys after module return isn't possible. This is a deliberate design choice intended to make exports easier to optimize.
+There is no future plan to allow exported variables to be reassigned after sealing. This is a deliberate design choice intended to make exports easier to optimize across modules.
 
-The shadowing rules for exported variables with relation to non-exported variables may lead to confusion. Similarly, reassigning exported variables in a large file may be as equally confusing. Users are encouraged to declare their exported variables with const if they do not intend to reassign them in the module.
+The shadowing rules for exported variables with relation to non-exported variables may lead to confusion. Similarly, reassigning exported variables in large files may be as equally confusing. Users are encouraged to use shadowing lints and declare their exported variables as const if they do not intend to reassign them in the module.
 
-Uninitialized exported variables pose a footgun where one can declare an uninitialized variable that is never reassigned to. This can be solved with linting.
+Uninitialized exported variables also pose a footgun where one can export a variable that is never reassigned to. This can be solved with linting.
 
 ## Alternatives
 
 As always, do nothing and leave users to construct their own module return tables. This would forfeit providing a consistent way for users to expose public APIs and would not allow for future cross-module optimizations.
 
-Permitting exports in `do end` blocks can be scrapped, but this would prevent users from scoping exported declarations and doesn't make much sense not to support. It is also possible to initially not support this and then add it back in later.
+It is feasible to also permit exports in `do end` blocks under the top scope, which would allow users to cleanly scope exported definitions with their dependencies. This is deferred to a future RFC as it is backwards compatible to reimplement later.
 
-An earlier version of the exported variable syntax omitted declaration keywords, such as with `export x = 1`. This was changed in lieu of the addition of const.
+An earlier version of the exported variable syntax omitted declaration keywords, such as with `export x = 1`. This was changed in light of the addition of const.
 
-Exported functions may instead not be automatically const, or declaration keywords may be allowed before exported functions such as with `export const function f() end`. Neither of these options are done since reassigning function declarations is already discouraged practice, and adding more keywords between function exports makes it unnecessarily verbose.
+Exporting function declarations may reuse different syntax that mirrors current local and const functions, such as with `export local function f()`. This was deemed unnecessarily verbose, with the current behavior of treating all exported functions as const being reasonable since reassigning function declarations is discouraged practice.
 
-All exported variables could be treated as const with applicable syntax changes. However, this makes many useful patterns such as exporting mutually dependent functions hard to pull off. Furthermore, introducing categorical const-ness would not allow for any more optimization opportunities.
+All exported variables could be treated as const with applicable syntax changes. However, this makes many useful patterns such as exporting mutually dependent functions hard to pull off. Furthermore, introducing categorical const-ness would not open the door to any more optimization opportunities.

--- a/docs/export-keyword.md
+++ b/docs/export-keyword.md
@@ -198,6 +198,15 @@ export local a = 1 -- syntax error
 
 This restriction does not apply to modules that only contain type exports for backwards compatibility.
 
+### Annotations
+Function annotations are also supported for exported functions and can go before the export keyword.
+
+```luau
+@native
+export function foo()
+end
+```
+
 ### Future Optimizations
 
 While the primary purpose for extending exports is user ergonomics, first-class exports also open the door to many optimizations that aren't currently possible with dynamic module returns.

--- a/docs/export-keyword.md
+++ b/docs/export-keyword.md
@@ -1,8 +1,7 @@
-
 # Export by Value
 
 ## Summary
-Extend the `export` keyword to support values and functions as syntax sugar for constructing a table and returning it from a module.
+Extend the `export` keyword to support variables and functions as syntax sugar for constructing a table and returning it from a module.
 
 ## Motivation
 Today, type aliases are able to be exported from a module using the `export` keyword.
@@ -13,17 +12,22 @@ export type Point = {x: number, y: number}
 
 However, this mechanism is currently only supported by types.
 
-Extending  `export`  to also support values and functions would provide a consistent way for users to expose a stable API from modules. Furthermore, static exports would allow for many future optimizations, such as cross-module inlining and constant folding.
+Extending  `export`  to also support variable and function declarations would provide a consistent way for users to expose a stable API from modules.
+
+Furthermore, introducing a language-level concept of exporting opens the door to many optimizations not currently possible with dynamic module returns, such as cross-module inlining and constant-folding.
 
 ## Design
-Allow the `export` contextual keyword anywhere the `local` keyword may be used at the top level of a module, as well as within nested `do end` blocks. Attempting to export a variable outside the module scope will be a parse error.
+The `export` contextual keyword will now be allowed anywhere before variable and function declarations at the top level of a module, including `local`, `const` and `function` declarations.
+
+Exporting declarations that are in nested `do end` blocks under the top scope are also permitted. Attempting to export a declaration outside the module scope will result in a parse error.
 
 Exported variables will count towards the local variable limit, as they can be optimized into locals by the compiler.
 
 ```luau
-export version = "5.1"
+export local version = "5.1"
+export const TAU = math.pi * 2
 
-export function init()
+export function init() -- exported functions are always const
 	-- TODO
 end
 
@@ -38,24 +42,25 @@ end
 -- counter and increment not visible here
 
 if foo then
-	export bar = 1 -- not allowed, syntax error
+	export local bar = 1 -- not allowed, syntax error
 end
 ```
 
-Just like local variable declarations, it is possible to export multiple variables, variables with type annotations, and uninitialized variables.
+Just like normal variable declarations, it is possible to export multiple variables, variables with type annotations, uninitialized variables, and const variables.
 
 ```luau
-export settings: Settings = getSettings()
-export a, b, c = 1, 2, 3
-export d -- same as export d = nil
+export local settings: Settings = getSettings()
+export local a, b, c = 1, 2, 3
+export local d -- same as export d = nil
+export const MAX_ITEMS = 10 -- cannot be reassigned
 ```
 
 Exporting a variable with the same identifier twice is a parse error, regardless of the scope it was defined in.
 
 ```luau
-export foo = 1
+export local foo = 1
 do
-	export foo = 2 -- syntax error
+	export local foo = 2 -- syntax error
 end
 ```
 
@@ -68,21 +73,28 @@ export function foo() return 2 end -- exported, shadows foo
 print(foo()) -- 2
 
 local fruit = "apple"
-export fruit -- exports fruit = nil, not "apple"
+export local fruit -- exports fruit = nil, not "apple"
 print(fruit) -- nil
 
-export animal = "dog"
+export local animal = "dog"
 local animal = "cat" -- shadows animal, doesn't change export
 animal = "bird"
 
 print(animal) -- bird
 ```
 
+Exported function declarations are also always treated as const, as reassigning function declarations is usually a mistake.
+
+```luau
+export function f() end
+f = 1 -- illegal
+```
+
 ### Desugared Form
 Exporting variables desugars into assigning keys to a table that is then frozen and returned once the module scope ends.
 
 ```luau
-export a = 1
+export local a = 1
 
 -- desugars into
 
@@ -91,15 +103,15 @@ _EXP.a = 1
 return table.freeze(_EXP)
 ```
 
-Exported variables can therefore be reassigned within the module after being declared. This allows for conditional exports and forward declarations.
+Exported local variables can therefore be reassigned within the module after being declared. This allows for conditional exports and forward declarations.
 
 ```luau
-export side = "heads"
+export local side = "heads"
 if math.random(0, 1) == 1 then
 	side = "tails"
 end
 
-export f, g
+export local f, g
 function f()
 	g()
 end
@@ -129,7 +141,7 @@ return table.freeze(_EXP)
 Once the module ends and the export table is frozen, subsequent reassignments will throw a runtime error, analogous to reassigning keys to a frozen table.
 
 ```luau
-export counter = 0
+export local counter = 0
 
 export function increment()
 	-- once the module returns
@@ -153,15 +165,14 @@ return table.freeze(_EXP)
 Type inference of exported variables will behave exactly the same as local variable inference.
 
 ```luau
--- example behavior subject to change
--- with local variable inference changes
+-- example behavior subject to change with local inference changes
 
-export foo = 15
+export local foo = 15
 foo = "hello"
 foo = true
 -- foo: number | string | boolean
 
-export bar = nil
+export local bar = nil
 if math.random(0, 1) == 1 then
 	bar = 123
 end
@@ -184,72 +195,59 @@ end
 return table.freeze(_EXP)
 ```
 
-This is done to ensure exported variables act exactly the same as local variables and preserve the same ergonomics.
+This is done to ensure exported variables act exactly the same as normal variables and preserve the same ergonomics.
 
 ### Interaction with `return`
 
 A module that contains an export statement is not permitted to also contain a return statement at the module scope, as the two mechanisms are mutually exclusive. If there is both an export statement and return statement, it is a parse error.
 
 ```luau
-export a = 1
+export local a = 1
 return {b = 2} -- syntax error
 ```
 ```luau
 if skip then return end
-export a = 1 -- syntax error
+export local a = 1 -- syntax error
 ```
 
 This restriction does not apply to modules that only contain type exports for backwards compatibility.
 
 ### Future Optimizations
 
-While the primary purpose for extending exports is user ergonomics, static exports also open the door for many optimizations that aren't currently possible with dynamic module returns.
+While the primary purpose for extending exports is user ergonomics, first-class exports also open the door to many optimizations that aren't currently possible with dynamic module returns.
 
-For example, exported variables and functions can be transformed into local variables that are stored in VM registers for fast lookup:
+For example, exported variables and functions can be transformed into local variables that are stored in VM registers for faster lookup:
 
 ```luau
-export tau = math.pi * 2
-print(tau)
+export const TAU = math.pi * 2
+print(TAU)
 
 -- becomes
-local tau = math.pi * 2
-print(tau)
-return table.freeze({tau = tau})
+const TAU = math.pi * 2
+print(TAU)
+return table.freeze({TAU = TAU})
 ```
 
-Furthermore, static exports that are never reassigned to are capable of being inlined and constant folded across modules, assuming future support for static imports.
+Furthermore, first-class exports allow for the compiler to assume exported variables are never reassigned after module return, unlocking the ability to bring constant-folding and inlining across module boundaries.
 
 ## Drawbacks
 
-This increases compiler complexity in terms of tracking exported tokens and converting them into table assignments.
+This increases compiler complexity in terms of tracking exported declarations and converting them into table assignments.
 
-Since `export` is a contextual keyword, the following statements are valid and might cause confusion. These cases can be solved with current linting and typechecking tools.
+Allowing reassignment of exported keys after module return isn't possible. This is a deliberate design choice intended to make exports easier to optimize.
 
-```luau
-export = 1
-export(1)
-export "a"
-export {x = 1}
-```
+The shadowing rules for exported variables with relation to non-exported variables may lead to confusion. Similarly, reassigning exported variables in a large file may be as equally confusing. Users are encouraged to declare their exported variables with const if they do not intend to reassign them in the module.
 
-Similarly, future RFCs such as a theoretical table destructing RFC may run into syntax ambiguities with export declarations, such as below. The first option could still be parsed with lookahead, but the second option would not be possible.
-
-```luau
-export {a, b} = t -- looks like export({a, b}) = t
-export [a] = t -- looks like export[a] = t
-```
-
-Uninitialized exported variables may also cause confusion due to looking like "shorthand exports" that export previously defined variables. For example, the following does not export the function `foo` but instead declares an exported variable that shadows it. This can be solved by implementing a lint that warns about uninitialized exports that are never assigned to.
-
-```luau
-local function foo(x) return x * 2 end
-export foo -- exports nil, shadows foo
-```
+Uninitialized exported variables pose a footgun where one can declare an uninitialized variable that is never reassigned to. This can be solved with linting.
 
 ## Alternatives
 
 As always, do nothing and leave users to construct their own module return tables. This would forfeit providing a consistent way for users to expose public APIs and would not allow for future cross-module optimizations.
 
-Permitting exports in `do end` blocks can be scraped, but this would prevent users from scoping exported variables and doesn't make much sense not to support. It is also possible to initially not support this and then add it back in later.
+Permitting exports in `do end` blocks can be scrapped, but this would prevent users from scoping exported declarations and doesn't make much sense not to support. It is also possible to initially not support this and then add it back in later.
 
-Exported variables could be treated as unassignable after declaration (like `const` variables in JavaScript), but this would make useful patterns such as exporting mutually dependent functions hard to pull off. Furthermore, introducing const-ness to the language would not provide any further optimization opportunities, as the compiler can already determine if a variable is constant if it is never reassigned to.
+An earlier version of the exported variable syntax omitted declaration keywords, such as with `export x = 1`. This was changed in lieu of the addition of const.
+
+Exported functions may instead not be automatically const, or declaration keywords may be allowed before exported functions such as with `export const function f() end`. Neither of these options are done since reassigning function declarations is already discouraged practice, and adding more keywords between function exports makes it unnecessarily verbose.
+
+All exported variables could be treated as const with applicable syntax changes. However, this makes many useful patterns such as exporting mutually dependent functions hard to pull off. Furthermore, introducing categorical const-ness would not allow for any more optimization opportunities.

--- a/docs/export-keyword.md
+++ b/docs/export-keyword.md
@@ -198,8 +198,8 @@ export local a = 1 -- syntax error
 
 This restriction does not apply to modules that only contain type exports for backwards compatibility.
 
-### Annotations
-Function annotations are also supported for exported functions and can go before the export keyword.
+### Attributes
+Function attributes are also supported for exported functions and can go before the export keyword.
 
 ```luau
 @native

--- a/docs/export-keyword.md
+++ b/docs/export-keyword.md
@@ -49,13 +49,32 @@ export a, b, c = 1, 2, 3
 export d -- same as export d = nil
 ```
 
-Unlike local variable declarations, exporting a variable with the same identifier twice is a syntax error, regardless of the scope it was declared in.
+Exporting a variable with the same identifier twice is a syntax error, regardless of the scope it was defined in.
 
 ```luau
 export foo = 1
 do
 	export foo = 2 -- syntax error
 end
+```
+
+However, exporting a variable with the same identifier as another non-exported variable is allowed, following conventional lexical scoping and shadowing rules.
+
+```luau
+local function foo() return 1 end
+export function foo() return 2 end -- exported, shadows foo
+
+print(foo()) -- 2
+
+local fruit = "apple"
+export fruit -- exports fruit = nil, not "apple"
+print(fruit) -- nil
+
+export animal = "dog"
+local animal = "cat" -- shadows animal, doesn't change export
+animal = "bird"
+
+print(animal) -- bird
 ```
 
 ### Desugared Form

--- a/docs/export-keyword.md
+++ b/docs/export-keyword.md
@@ -1,4 +1,5 @@
-# Export-by-Value
+
+# Export by Value
 
 ## Summary
 Extend the `export` keyword to support values and functions as syntax sugar for constructing a table and returning it from a module.
@@ -10,12 +11,12 @@ Today, type aliases are able to be exported from a module using the `export` key
 export type Point = {x: number, y: number}
 ```
 
-However, this mechanism is currently limited to types.
+However, this mechanism is currently only supported by types.
 
-Extending  `export`  to support values and functions would provide a consistent way for users to expose a stable API from a module. Furthermore, first-class module exports can provide future static optimization opportunities, such as cross-module inlining and constant folding.
+Extending  `export`  to also support values and functions would provide a consistent way for users to expose a stable API from modules. Furthermore, static exports would allow for many future optimizations, such as cross-module inlining and constant folding.
 
 ## Design
-Allow the `export` contextual keyword anywhere the `local` keyword may be used at the top level of a module, as well as within nested `do end` blocks.
+Allow the `export` contextual keyword anywhere the `local` keyword may be used at the top level of a module, as well as within nested `do end` blocks. Attempting to export a variable outside the module scope will be a parse error.
 
 Exported variables will count towards the local variable limit, as they can be optimized into locals by the compiler.
 
@@ -49,7 +50,7 @@ export a, b, c = 1, 2, 3
 export d -- same as export d = nil
 ```
 
-Exporting a variable with the same identifier twice is a syntax error, regardless of the scope it was defined in.
+Exporting a variable with the same identifier twice is a parse error, regardless of the scope it was defined in.
 
 ```luau
 export foo = 1
@@ -90,7 +91,7 @@ _EXP.a = 1
 return table.freeze(_EXP)
 ```
 
-Exported values can therefore be reassigned within the module after being declared. This allows for conditional exported values and forward declarations.
+Exported variables can therefore be reassigned within the module after being declared. This allows for conditional exports and forward declarations.
 
 ```luau
 export side = "heads"
@@ -125,7 +126,7 @@ end
 return table.freeze(_EXP)
 ```
 
-Once the module ends and the export table is frozen, subsequent reassignments will throw a runtime error, analogous to attempting to assign a key in a frozen table.
+Once the module ends and the export table is frozen, subsequent reassignments will throw a runtime error, analogous to reassigning keys to a frozen table.
 
 ```luau
 export counter = 0
@@ -148,13 +149,50 @@ end
 return table.freeze(_EXP)
 ```
 
+### Typechecking
+Type inference of exported variables will behave exactly the same as local variable inference.
+
+```luau
+-- example behavior subject to change
+-- with local variable inference changes
+
+export foo = 15
+foo = "hello"
+foo = true
+-- foo: number | string | boolean
+
+export bar = nil
+if math.random(0, 1) == 1 then
+	bar = 123
+end
+-- bar: number?
+```
+
+This is in contrast to how typechecking would behave in the desugared form with key assignments.
+
+```luau
+local _EXP = {}
+_EXP.foo = 15
+_EXP.foo = "hello" -- type error
+_EXP.foo = true -- type error
+
+_EXP.bar = nil
+if math.random(0, 1) == 1 then
+	_EXP.bar = 123 -- type error
+end
+
+return table.freeze(_EXP)
+```
+
+This is done to ensure exported variables act exactly the same as local variables and preserve the same ergonomics.
+
 ### Interaction with `return`
 
-A module that contains an export statement is not permitted to also contain a return statement at the module scope, as the two mechanisms are mutually exclusive. If there is both an export statement and return statement, it is a syntax error.
+A module that contains an export statement is not permitted to also contain a return statement at the module scope, as the two mechanisms are mutually exclusive. If there is both an export statement and return statement, it is a parse error.
 
 ```luau
 export a = 1
-return 2 -- syntax error
+return {b = 2} -- syntax error
 ```
 ```luau
 if skip then return end
@@ -165,9 +203,9 @@ This restriction does not apply to modules that only contain type exports for ba
 
 ### Future Optimizations
 
-While static first-class exports primarily provide improvements to user ergonomics, they also open the door for many optimizations that aren't currently possible with dynamic module returns.
+While the primary purpose for extending exports is user ergonomics, static exports also open the door for many optimizations that aren't currently possible with dynamic module returns.
 
-For example, exported variables and functions could be transformed into local variables that are stored in VM registers for fast lookup:
+For example, exported variables and functions can be transformed into local variables that are stored in VM registers for fast lookup:
 
 ```luau
 export tau = math.pi * 2
@@ -179,13 +217,13 @@ print(tau)
 return table.freeze({tau = tau})
 ```
 
-Furthermore, static exports that are never reassigned are capable of being inlined and constant folded across modules, given future static imports.
+Furthermore, static exports that are never reassigned to are capable of being inlined and constant folded across modules, assuming future support for static imports.
 
 ## Drawbacks
 
 This increases compiler complexity in terms of tracking exported tokens and converting them into table assignments.
 
-Since `export` is a contextual keyword, the following statements are valid and might cause confusion. These are solved by current linting and typechecking.
+Since `export` is a contextual keyword, the following statements are valid and might cause confusion. These cases can be solved with current linting and typechecking tools.
 
 ```luau
 export = 1
@@ -201,12 +239,17 @@ export {a, b} = t -- looks like export({a, b}) = t
 export [a] = t -- looks like export[a] = t
 ```
 
+Uninitialized exported variables may also cause confusion due to looking like "shorthand exports" that export previously defined variables. For example, the following does not export the function `foo` but instead declares an exported variable that shadows it. This can be solved by implementing a lint that warns about uninitialized exports that are never assigned to.
+
+```luau
+local function foo(x) return x * 2 end
+export foo -- exports nil, shadows foo
+```
+
 ## Alternatives
 
-As always, do nothing and leave users to construct their own module return tables. This would forfeit providing a consistent way for users to expose a public API and would not allow for future cross-module optimizations.
+As always, do nothing and leave users to construct their own module return tables. This would forfeit providing a consistent way for users to expose public APIs and would not allow for future cross-module optimizations.
 
-Exporting in `do end` blocks under the module scope can be scrapped, but this would prevent users from lexically scoping exported variables and doesn't make much sense not to support. It is also possible to initially not support this and then add it back in later.
+Permitting exports in `do end` blocks can be scraped, but this would prevent users from scoping exported variables and doesn't make much sense not to support. It is also possible to initially not support this and then add it back in later.
 
-Exported variables could be treated as unassignable after initialization (like `const` variables in JavaScript), but this would make useful patterns such as exporting mutually dependent functions hard to pull off. Furthermore, introducing const-ness to the language would not provide any further optimization opportunities, as the compiler can already determine if a variable is constant if it is never reassigned to.
-
-So-called "shorthand exports" could also be introduced to allow exporting local variables after they've been declared. This only makes sense under the model that exports are unassignable and introduces confusing semantics regarding variable aliasing.
+Exported variables could be treated as unassignable after declaration (like `const` variables in JavaScript), but this would make useful patterns such as exporting mutually dependent functions hard to pull off. Furthermore, introducing const-ness to the language would not provide any further optimization opportunities, as the compiler can already determine if a variable is constant if it is never reassigned to.

--- a/docs/export-keyword.md
+++ b/docs/export-keyword.md
@@ -1,0 +1,193 @@
+# Export-by-Value
+
+## Summary
+Extend the `export` keyword to support values and functions as syntax sugar for constructing a table and returning it from a module.
+
+## Motivation
+Today, type aliases are able to be exported from a module using the `export` keyword.
+
+```luau
+export type Point = {x: number, y: number}
+```
+
+However, this mechanism is currently limited to types.
+
+Extending  `export`  to support values and functions would provide a consistent way for users to expose a stable API from a module. Furthermore, first-class module exports can provide future static optimization opportunities, such as cross-module inlining and constant folding.
+
+## Design
+Allow the `export` contextual keyword anywhere the `local` keyword may be used at the top level of a module, as well as within nested `do end` blocks.
+
+Exported variables will count towards the local variable limit, as they can be optimized into locals by the compiler.
+
+```luau
+export version = "5.1"
+
+export function init()
+	-- TODO
+end
+
+do
+	local counter = 0
+	
+	export function increment(): number
+		counter += 1
+		return counter
+	end
+end
+-- counter and increment not visible here
+
+if foo then
+	export bar = 1 -- not allowed, syntax error
+end
+```
+
+Just like local variable declarations, it is possible to export multiple variables, variables with type annotations, and uninitialized variables.
+
+```luau
+export settings: Settings = getSettings()
+export a, b, c = 1, 2, 3
+export d -- same as export d = nil
+```
+
+Unlike local variable declarations, exporting a variable with the same identifier twice is a syntax error, regardless of the scope it was declared in.
+
+```luau
+export foo = 1
+do
+	export foo = 2 -- syntax error
+end
+```
+
+### Desugared Form
+Exporting variables desugars into assigning keys to a table that is then frozen and returned once the module scope ends.
+
+```luau
+export a = 1
+
+-- desugars into
+
+local _EXP = {}
+_EXP.a = 1
+return table.freeze(_EXP)
+```
+
+Exported values can therefore be reassigned within the module after being declared. This allows for conditional exported values and forward declarations.
+
+```luau
+export side = "heads"
+if math.random(0, 1) == 1 then
+	side = "tails"
+end
+
+export f, g
+function f()
+	g()
+end
+function g()
+	f()
+end
+
+-- desugars into
+
+local _EXP = {}
+_EXP.side = "heads"
+if math.random(0, 1) == 1 then
+	_EXP.side = "tails"
+end
+
+_EXP.f, _EXP.g = nil, nil
+function _EXP.f()
+	_EXP.g()
+end
+function _EXP.g()
+	_EXP.f()
+end
+
+return table.freeze(_EXP)
+```
+
+Once the module ends and the export table is frozen, subsequent reassignments will throw a runtime error, analogous to attempting to assign a key in a frozen table.
+
+```luau
+export counter = 0
+
+export function increment()
+	-- once the module returns
+	-- this raises an "attempt to modify a readonly table" error
+	counter += 1
+end
+
+-- desugars into
+
+local _EXP = {}
+_EXP.counter = 0
+
+function _EXP.increment()
+	_EXP.counter += 1
+end
+
+return table.freeze(_EXP)
+```
+
+### Interaction with `return`
+
+A module that contains an export statement is not permitted to also contain a return statement at the module scope, as the two mechanisms are mutually exclusive. If there is both an export statement and return statement, it is a syntax error.
+
+```luau
+export a = 1
+return 2 -- syntax error
+```
+```luau
+if skip then return end
+export a = 1 -- syntax error
+```
+
+This restriction does not apply to modules that only contain type exports for backwards compatibility.
+
+### Future Optimizations
+
+While static first-class exports primarily provide improvements to user ergonomics, they also open the door for many optimizations that aren't currently possible with dynamic module returns.
+
+For example, exported variables and functions could be transformed into local variables that are stored in VM registers for fast lookup:
+
+```luau
+export tau = math.pi * 2
+print(tau)
+
+-- becomes
+local tau = math.pi * 2
+print(tau)
+return table.freeze({tau = tau})
+```
+
+Furthermore, static exports that are never reassigned are capable of being inlined and constant folded across modules, given future static imports.
+
+## Drawbacks
+
+This increases compiler complexity in terms of tracking exported tokens and converting them into table assignments.
+
+Since `export` is a contextual keyword, the following statements are valid and might cause confusion. These are solved by current linting and typechecking.
+
+```luau
+export = 1
+export(1)
+export "a"
+export {x = 1}
+```
+
+Similarly, future RFCs such as a theoretical table destructing RFC may run into syntax ambiguities with export declarations, such as below. The first option could still be parsed with lookahead, but the second option would not be possible.
+
+```luau
+export {a, b} = t -- looks like export({a, b}) = t
+export [a] = t -- looks like export[a] = t
+```
+
+## Alternatives
+
+As always, do nothing and leave users to construct their own module return tables. This would forfeit providing a consistent way for users to expose a public API and would not allow for future cross-module optimizations.
+
+Exporting in `do end` blocks under the module scope can be scrapped, but this would prevent users from lexically scoping exported variables and doesn't make much sense not to support. It is also possible to initially not support this and then add it back in later.
+
+Exported variables could be treated as unassignable after initialization (like `const` variables in JavaScript), but this would make useful patterns such as exporting mutually dependent functions hard to pull off. Furthermore, introducing const-ness to the language would not provide any further optimization opportunities, as the compiler can already determine if a variable is constant if it is never reassigned to.
+
+So-called "shorthand exports" could also be introduced to allow exporting local variables after they've been declared. This only makes sense under the model that exports are unassignable and introduces confusing semantics regarding variable aliasing.


### PR DESCRIPTION
This proposes alternative semantics for #42, which treats exports as syntax sugar for assigning keys to an export table before sealing.

This allows reassigning exported values before the module is returned, solving the original RFC's issues with mutually dependent functions and shorthand aliasing. Furthermore, it introduces export semantics that are already representable in the language, dismissing the need for introducing `const`-ness to the language.

[Rendered](https://github.com/MagmaBurnsV/rfcs/blob/34e2efcc3d5f0895570cea8e104bac66505a72ae/docs/export-keyword.md)