### PR TITLE
Add `globaldefinitions` to `.config.luau` for Luau embedders

### DIFF
--- a/docs/config-luauconfig.md
+++ b/docs/config-luauconfig.md
@@ -32,6 +32,7 @@ return {
         linterrors = true,
         typeerrors = true,
         globals = {"expect"},
+        globaldefinitions = "./embed.d.luau",
         aliases = {
             src = "./src"
         }
@@ -81,6 +82,7 @@ type LuauConfig = {
     linterrors: boolean?,
     typeerrors: boolean?,
     globals: { string }?,
+    globaldefinitions: string?,
     aliases: { [string]: string }?,
 }
 

--- a/docs/config-luaurc.md
+++ b/docs/config-luaurc.md
@@ -26,6 +26,7 @@ applied. When multiple files are used, the file closer to the .lua file override
 - `"lintErrors"`: a boolean that controls whether lint issues are reported as errors or warnings (off by default)
 - `"typeErrors"`: a boolean that controls whether type issues are reported as errors or warnings (on by default)
 - `"globals"`: extra global values; points to an array of strings where each string names a global that the type checker and linter must assume is valid and of type `any`
+- `"globalDefinitions"`: string path to a local filename. This is a file in the same luau-like language embedded inside `Analysis/src/EmbeddedBuiltinDefinitions.cpp`, and provides additional global definitions to the typechecker and linter. 
 
 Example of a valid .luaurc file:
 
@@ -34,7 +35,8 @@ Example of a valid .luaurc file:
 	"languageMode": "nonstrict",
 	"lint": { "*": true, "LocalUnused": false },
 	"lintErrors": true,
-	"globals": ["expect"] // TestEZ
+	"globals": ["expect"], // TestEZ
+	"globalDefinitions" = "./embed.d.luau",
 }
 ```
 

--- a/docs/config-luaurc.md
+++ b/docs/config-luaurc.md
@@ -36,7 +36,7 @@ Example of a valid .luaurc file:
 	"lint": { "*": true, "LocalUnused": false },
 	"lintErrors": true,
 	"globals": ["expect"], // TestEZ
-	"globalDefinitions" = "./embed.d.luau",
+	"globalDefinitions" = "./embed.d.luau"
 }
 ```
 


### PR DESCRIPTION
- [.config.luau Rendered](https://github.com/tapple/luau-rfcs/blob/analyze-definitions/docs/config-luauconfig.md)
- [.luaurc Rendered](https://github.com/tapple/luau-rfcs/blob/analyze-definitions/docs/config-luaurc.md)

## Motivation

Luau is designed to be embeddable, and embedders can add additional tables, functions, and userdata types to their Luau globals as they see fit. However, the design of the typechecker tools `luau-analyze` and `lute check` does not honor this extensibility, and gives no way for embedders to tell the typechecker about their additions.

Third-party tools like `luau-lsp` and `selene` do provide such a mechanism. This proposal aims to bring that capability to the first-party typechecking and linting tools via the standard `.luaurc` and `.config.luau` files via a new field named `globaldefinitions`.

This field will point to a file in the same format as already widely used by `luau-lsp`. This format is not formally specified, but it is informally specified by example in [EmbeddedBuiltinDefinitions.cpp](https://github.com/luau-lang/luau/blob/master/Analysis/src/EmbeddedBuiltinDefinitions.cpp)

This proposal does not aim to formally specify this document, just to provide a mechanism to use it without `luau-lsp`

Inspired by the `--defs` parameter of `luau-lsp`:
```
luau-lsp analyze --defs @sl=.vscode/sl-vscode-plugin/secondlife.d.luau PropTest.luau
```

and the `std` parameter of `selene.toml`:
```toml
std = ".vscode/sl-vscode-plugin/secondlife_selene"
```

## Alternatives
- https://github.com/luau-lang/lute/issues/1064
- Add `--defs` parameter to `luau-analyze`