### PR TITLE
RFC: Name support for all Type Pack annotations

### DIFF
--- a/docs/syntax-type-labels.md
+++ b/docs/syntax-type-labels.md
@@ -157,3 +157,8 @@ type MySignal = WrappedSignal<(label1: number, label2: string) -> ()>
 ```
 And this would also mean that ``WrappedSignal`` needs to implement a type function now, that takes out the argument names and transforms ``.FireToFoo``.
 And that sounds too complicated.
+
+You don't want it to be
+
+You don't want it to be ``(targetFoo: Foo: Player, (label1: number, label2: string) -> ()) -> ()``
+you want ``(targetFoo: Foo: Player, label1: number, label2: string) -> ()``.

--- a/docs/syntax-type-labels.md
+++ b/docs/syntax-type-labels.md
@@ -160,5 +160,5 @@ And that sounds too complicated.
 
 You don't want it to be
 
-You don't want it to be ``( targetFoo: Foo: Player, (label1: number, label2: string) -> () ) -> ()``
+You want it to be ``( targetFoo: Foo: Player, (label1: number, label2: string) -> () ) -> ()``
 you want ``(targetFoo: Foo: Player, label1: number, label2: string) -> ()``.

--- a/docs/syntax-type-labels.md
+++ b/docs/syntax-type-labels.md
@@ -160,5 +160,5 @@ And that sounds too complicated.
 
 You don't want it to be
 
-You don't want it to be ``(targetFoo: Foo: Player, (label1: number, label2: string) -> ()) -> ()``
+You don't want it to be ``( targetFoo: Foo: Player, (label1: number, label2: string) -> () ) -> ()``
 you want ``(targetFoo: Foo: Player, label1: number, label2: string) -> ()``.

--- a/docs/syntax-type-labels.md
+++ b/docs/syntax-type-labels.md
@@ -3,7 +3,7 @@
 ## Summary
 
 Syntax type labels intended for generic types, allowing users to attach parameter names to types for use in argument types.
-This is to improve IntelliSense and autocomplete, and allows custom callbacks to show you argument names, instead of just the type.
+This is to improve IntelliSense and autocomplete, and allows custom callbacks to show you argument names instead of just the type.
 
 ## Motivation
 
@@ -14,15 +14,17 @@ type Callback = (x: number, y: number, z: number) -> ()
 
 local cb: Callback = function()
   --[[
-    IntelliSense shows you  cb: (x: number, y: number, z: number) -> ().
-    Luau Playground just shows cb: (number, number, number) -> ()
+    IntelliSense shows you
+		cb: (x: number, y: number, z: number) -> ().
+    Luau Playground just shows
+		cb: (number, number, number) -> ()
   --]]
 end
 ```
 
 But here in this case, a developer would immediately know what each of these type _represents_. In this case ``x``, ``y`` and ``z``.
 
-Luau and any embedder internally in the implementation, is able to define argument names in some way or another.
+Luau and any embedder internally within the implementation are able to define argument names in some way or another to types _procedurally_.
 But a developer is not able to replicate everything from the implementation itself.
 
 <br/>

--- a/docs/syntax-type-labels.md
+++ b/docs/syntax-type-labels.md
@@ -1,0 +1,157 @@
+# Syntax Type Labels
+
+## Summary
+
+Syntax type labels intended for generic types, allowing users to attach parameter names to types for use in argument types.
+This is to improve IntelliSense and autocomplete, and allows custom callbacks to show you argument names, instead of just the type.
+
+## Motivation
+
+Currently, you can only provide argument names in a type by doing the following.
+
+```luau
+type Callback = (x: number, y: number, z: number) -> ()
+
+local cb: Callback = function()
+  --[[
+    IntelliSense shows you  cb: (x: number, y: number, z: number) -> ().
+    Luau Playground just shows cb: (number, number, number) -> ()
+  --]]
+end
+```
+
+But here in this case, a developer would immediately know what each of these type _represents_. In this case ``x``, ``y`` and ``z``.
+
+Luau and any embedder internally in the implementation, is able to define argument names in some way or another.
+But a developer is not able to replicate everything from the implementation itself.
+
+<br/>
+
+Generic packs exist
+
+```luau
+type WrappedSignal<T...> = {
+	FireToFoo: (self: WrappedSignal<T...>, targetFoo: Foo, T...) -> (),
+}
+
+type MySignal = WrappedSignal<number, string>
+```
+
+But in this case, the result of ``MySignal.FireToFoo`` would show up as:
+```luau
+(WrappedSignal<T...>, Foo, number, string)
+-- or
+(self: WrappedSignal<T...>, targetFoo: Foo, number, string)
+```
+without any context or indication on what these provided types ``(number, string)`` are meant to re-present.
+
+But you can see that ``targetFoo: Foo`` is present, but only because function annotations specifically let you describe argument names, which APIs can pick-up on.
+
+<br/>
+
+Luau already allows you to provide parameter names.
+
+```luau
+(x: number) -> ()
+```
+
+But when generic types are used, this information is no longer available
+
+```luau
+type Callback<T...> = (T...) -> ()
+```
+
+``T...`` will only emit over types but not labels.
+
+And currently, there isn't even syntax to provide a label when using ``Callback<T...>``
+
+
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+## Design
+
+**Syntax Type Labels**, allowing users to provide semantics onto types,
+useful for IntelliSense and autocomplete, even for debug tooling within the internals of the language itself.
+_(a bit similar to TypeScript)_
+
+Labels are only metadata:
+- Labels are NOT enforced in any type checking way
+- They don't affect the type itself
+- They only improve front-end hints
+
+
+Type Labels are intended to be used while providing types into generics.
+```luau
+type Callback<T...> = (T...) -> ()
+
+function Foo(cb: Callback<[targetBar: Bar]> end
+-- cb shows (targetBar: Bar) -> ()
+```
+
+### Syntax:
+- Type Label Syntax is wrapped around these brackets ``[]``.
+- They can contain a label through ``[label: type]``, but is optional
+- ``[number]`` would just be ``number``
+- ``[x: number]`` would just be ``number``, with a label ``"x"``
+- Multiple types can appear in it by separating with ``,``
+  - ``[x: number, y: number]
+  - but this is also fine ``[x: number], [y: number]``
+
+Multiple types can only appear if multiple types are even allowed to be provided.
+```luau
+type Foo<T...> = (T...) -> ()
+type Bar<T> = (T) -> ()
+
+type A = Foo<[a: number, number, label: number]> -- allowed
+type B = Foo<[x: number], [y: number]> -- allowed
+
+type C = Bar<[x: number, y: number]> -- Error: More than one type!
+```
+
+<br/>
+### Usage:
+
+```luau
+type WrappedSignal<T...> = {
+	FireToFoo: (self: WrappedSignal<T...>, targetFoo: Foo, T...) -> (),
+}
+
+type MySignal = WrappedSignal<[amount: number, message: string]>
+
+--[[
+  MySignal.FireToFoo would become
+    (self: WrappedSignal<T...>, targetFoo: Foo, amount: number, message: string) -> ()
+]]
+```
+
+Nothing changes about the types own identity, it just gets associated with metadata.
+
+<br/>
+
+
+In TypeScript you can do
+```ts
+type Position = [x: number, y: number, z: number]
+```
+Luau does NOT support typing tuples in this context, so doing the above in Luau, would error.
+
+
+
+## Drawbacks
+
+- A new syntax has to be introduced. Another question would be whether "labels" will be the only thing, or whether there will be more.
+- Whether syntax should be ``[x: number, y: number, z: number]`` or ``[x: number], [y: number], [z: number]``
+- ``[]`` are used by table keys and indexing, or _"arrays"_ in other languages.
+
+## Alternatives
+
+Type functions could expose modifying argument names, but that would only work for function annotations, not on a type alone.
+There wouldn't be a way to attach a label to a type.
+
+```luau
+type WrappedSignal<T...> = { FireToFoo: (self: WrappedSignal<T...>, targetFoo: Foo, T...) -> (); }
+type MySignal = WrappedSignal<(label1: number, label2: string) -> ()>
+```
+And this would also mean that ``WrappedSignal`` needs to implement a type function now, that takes out the argument names and transforms ``.FireToFoo``.
+And that sounds too complicated.

--- a/docs/syntax-type-labels.md
+++ b/docs/syntax-type-labels.md
@@ -112,8 +112,8 @@ type C = Bar<[x: number, y: number]> -- Error: More than one type!
 ```
 
 <br/>
-### Usage:
 
+### Usage:
 ```luau
 type WrappedSignal<T...> = {
 	FireToFoo: (self: WrappedSignal<T...>, targetFoo: Foo, T...) -> (),

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -97,6 +97,7 @@ type MyNumber = (num: number) -- not valid not a type pack!
 ```luau
 type Foo<T...> = (T...) -> ()
 
+-- Names are optional
 type A = Foo<(a: number, number, label: number)> -- allowed
 type B = Foo<(x: number), (y: number)> -- not valid
 type C = Foo<(x: number, y: number)> -- valid

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -1,9 +1,9 @@
-# Syntax Type Labels
+# Names in Type Packs
 
 ## Summary
 
-Syntax type labels intended for generic types, allowing users to attach parameter names to types for use in argument types.
-This is to improve IntelliSense and autocomplete, and allows custom callbacks to show you argument names instead of just the type.
+Allowing users to always provide names within type packs, such as ``(x: number)`` syntax, would allow users to attach parameter names to a within a type pack.
+This improves IntelliSense and autocomplete, and allows custom callbacks to show you argument names instead of just the type.
 
 ## Motivation
 
@@ -73,42 +73,35 @@ Why are we doing this? What use cases does it support? What is the expected outc
 
 ## Design
 
-**Syntax Type Labels**, allowing users to provide semantics onto types,
-useful for IntelliSense and autocomplete, even for debug tooling within the internals of the language itself.
-_(a bit similar to TypeScript)_
+This syntax here ``(number)`` is a type pack.
 
-Labels are only metadata:
-- Labels are NOT enforced in any type checking way
+And the idea is to allow to provide names in any type pack syntax.
+
+e.g. allowing you to do ``(x: number)`` without being exclusively restricted to function annotations anymore.
+
+Names/Labels are only metadata:
+- Names/Labels are NOT enforced in any type checking way
 - They don't affect the type itself
 - They only improve front-end hints
 
 
-Type Labels are intended to be used while providing types into generics.
+### Example:
+
 ```luau
 type Callback<T...> = (T...) -> ()
 
-function Foo(cb: Callback<[targetBar: Bar]> end
+function Foo(cb: Callback<(targetBar: Bar)> end
 -- cb shows (targetBar: Bar) -> ()
 ```
 
-### Syntax:
-- Type Label Syntax is wrapped around these brackets ``[]``.
-- They can contain a label through ``[label: type]``, but is optional
-- ``[number]`` would just be ``number``
-- ``[x: number]`` would just be ``number``, with a label ``"x"``
-- Multiple types can appear in it by separating with ``,``
-  - ``[x: number, y: number]
-  - but this is also fine ``[x: number], [y: number]``
-
-Multiple types can only appear if multiple types are even allowed to be provided.
 ```luau
 type Foo<T...> = (T...) -> ()
 type Bar<T> = (T) -> ()
 
-type A = Foo<[a: number, number, label: number]> -- allowed
-type B = Foo<[x: number], [y: number]> -- allowed
+type A = Foo<(a: number, number, label: number)> -- allowed
+type B = Foo<(x: number), (y: number)> -- allowed
 
-type C = Bar<[x: number, y: number]> -- Error: More than one type!
+type C = Bar<(x: number, y: number)> -- Error: More than one type!
 ```
 
 <br/>
@@ -119,7 +112,7 @@ type WrappedSignal<T...> = {
 	FireToFoo: (self: WrappedSignal<T...>, targetFoo: Foo, T...) -> (),
 }
 
-type MySignal = WrappedSignal<[amount: number, message: string]>
+type MySignal = WrappedSignal<(amount: number, message: string)>
 
 --[[
   MySignal.FireToFoo would become
@@ -132,21 +125,22 @@ Nothing changes about the types own identity, it just gets associated with metad
 <br/>
 
 
-In TypeScript you can do
-```ts
-type Position = [x: number, y: number, z: number]
+```luau
+type MyNumber = (x: number)
+type Func = () -> (x: number, y: number, z: number)
 ```
-Luau does NOT support typing tuples in this context, so doing the above in Luau, would error.
+
 
 
 
 ## Drawbacks
 
-- A new syntax has to be introduced. Another question would be whether "labels" will be the only thing, or whether there will be more.
-- Whether syntax should be ``[x: number, y: number, z: number]`` or ``[x: number], [y: number], [z: number]``
-- ``[]`` are used by table keys and indexing, or _"arrays"_ in other languages.
+- Most likely none, other than the implementation.
+
 
 ## Alternatives
+
+- A new syntax where it would be ``[x: number, y: number, z: number]`` or ``[x: number], [y: number], [z: number]``
 
 Type functions could expose modifying argument names, but that would only work for function annotations, not on a type alone.
 There wouldn't be a way to attach a label to a type.

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -136,14 +136,6 @@ function Func2(): (a: number, b: number, c: number)
 end
 ```
 
-In the event where an annotation already has a name, we will keep the name if possible.
-```luau
-type Foo<T> = (arg: T) -> ()
-type A = Foo<(x: number)> -- "arg" stays.
-
-type Foo<T> = (T) -> ()
-type A = Foo<(x: number)> -- "T" had no name, so it gets given one!
-```
 
 
 
@@ -152,6 +144,13 @@ type A = Foo<(x: number)> -- "T" had no name, so it gets given one!
 
 - Most likely none, other than the implementation.
 - Whether ``(arg: T)`` should have ``"arg"`` replaced or not, if substituted by ``(x: number)``.
+
+
+We can't rename ``T`` here
+```luau
+type Foo<T> = (arg: T) -> ()
+type A = Foo<(x: number)> -- (x: number), does not count as a type pack
+```
 
 
 ## Alternatives

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -102,11 +102,12 @@ type Foo<T...> = (T...) -> ()
 
 -- Names are optional
 type A = Foo<(a: number, number, label: number)> -- allowed
-type B = Foo<(x: number), (y: number)> -- not valid
+
+type B = Foo<(x: number), (y: number)> -- not valid, they're not type packs
 type C = Foo<(x: number, y: number)> -- valid
 
 type D = (num: number) -> () -- already works in Luau, no changes!
-type E = () -> (num: number) -- valid!
+type E = () -> (num: number) -- valid
 ```
 
 ```luau
@@ -123,7 +124,6 @@ type WrappedSignal<T...> = {
 }
 
 type MySignal = WrappedSignal<(amount: number, message: string)>
-
 --[[
   MySignal.FireToFoo would become
     (self: WrappedSignal<T...>, targetFoo: Foo, amount: number, message: string) -> ()

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -45,7 +45,9 @@ But in this case, the result of ``MySignal.FireToFoo`` would show up as:
 -- or
 (self: WrappedSignal<T...>, targetFoo: Foo, number, string)
 ```
-without any context or indication on what these provided types ``(number, string)`` are meant to represent.
+There is no context or indication on what these provided types ``(number, string)`` are meant to represent.
+You don't want to use a function annotation to fill in ``T...`` because we want ``(self: WrappedSignal<T...>, targetFoo: Foo, number, string)``
+and not ``(self: WrappedSignal<T...>, targetFoo: Foo, (number, string) -> ())``.
 
 But you can see that ``targetFoo: Foo`` is present, but only because function annotations specifically let you describe argument names, which APIs can pick-up on.
 

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -22,7 +22,7 @@ local cb: Callback = function()
 end
 ```
 
-But here in this case, a developer would immediately know what each of these type _represents_. In this case ``x``, ``y`` and ``z``.
+But in the IntelliSense case, a developer would immediately know what each of these type _represents_. In this case ``x``, ``y`` and ``z``.
 
 Luau and any embedder internally within the implementation are able to define argument names in some way or another to types _procedurally_.
 But a developer is not able to replicate everything from the implementation itself.

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -63,7 +63,7 @@ But when generic types are used, this information is no longer available
 type Callback<T...> = (T...) -> ()
 ```
 
-``T...`` will only emit over types but not labels.
+``T...`` will only emit over types but not any names/labels.
 
 And currently, there isn't even syntax to provide a label when using ``Callback<T...>``
 

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -92,7 +92,7 @@ function Foo(cb: Callback<(targetBar: Bar)> end
 
 ```luau
 type Bar<T> = (T) -> ()
-type A = Bar<(num: number)> -- not valid (T) is not a type pack!
+type A = Bar<(num: number)> -- not valid, '(T)' is not a type pack!
 type MyNumber = (num: number) -- not valid not a type pack!
 ```
 

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -68,11 +68,10 @@ And currently, there isn't a way to provide a name/label when using ``Callback<T
 
 ## Design
 
-This syntax here ``(number)`` is a type pack.
 
-And the idea is to allow to provide names in any type pack syntax.
+The idea is to allow to describe names in any valid type pack context.
 
-e.g. allowing you to do ``(x: number)`` without being exclusively restricted to function annotations anymore.
+e.g. allowing you to do ``Type<(x: number)>`` if ``Type<T...>`` without being exclusively restricted to function annotations anymore.
 
 Names/Labels are only metadata:
 - Names/Labels are NOT enforced in any type checking way

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Allowing users to always provide names within type packs, such as ``(x: number)`` syntax, would allow users to attach parameter names to a within a type pack.
+Allowing users to always provide names within type packs ``(T...)``, so that parameter names can be attached to types.
 This improves IntelliSense and autocomplete, and allows custom callbacks to show you argument names instead of just the type.
 
 ## Motivation
@@ -51,25 +51,20 @@ But you can see that ``targetFoo: Foo`` is present, but only because function an
 
 <br/>
 
-Luau already allows you to provide parameter names.
-
+Luau already allows you to provide parameter names within function annotations.
 ```luau
 (x: number) -> ()
 ```
 
-But when generic types are used, this information is no longer available
-
+But when generic type packs are used, this information is no longer available.
 ```luau
 type Callback<T...> = (T...) -> ()
 ```
 
 ``T...`` will only emit over types but not any names/labels.
 
-And currently, there isn't even syntax to provide a label when using ``Callback<T...>``
+And currently, there isn't a way to provide a name/label when using ``Callback<T...>``
 
-
-
-Why are we doing this? What use cases does it support? What is the expected outcome?
 
 ## Design
 

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -85,7 +85,7 @@ Names/Labels are only metadata:
 - They only improve front-end hints
 
 
-### Example:
+### Usage and Examples:
 
 ```luau
 type Callback<T...> = (T...) -> ()
@@ -107,7 +107,6 @@ type D = (num: number) -> () -- Already works in Luau, no changes!
 
 <br/>
 
-### Usage:
 ```luau
 type WrappedSignal<T...> = {
 	FireToFoo: (self: WrappedSignal<T...>, targetFoo: Foo, T...) -> (),
@@ -129,6 +128,9 @@ Nothing changes about the types own identity, it just gets associated with metad
 ```luau
 type MyNumber = (x: number)
 type Func = () -> (x: number, y: number, z: number)
+function Func2(): (a: number, b: number, c: number)
+  return 1,2,3
+end
 ```
 
 In the event where an annotation already has a name. The name would get overwritten if...

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -77,6 +77,9 @@ Names/Labels are only metadata:
 - Names/Labels are NOT enforced in any type checking way
 - They don't affect the type itself
 - They only improve front-end hints
+- Nothing changes about the types own identity, it just gets associated with a name.
+- The name is NOT forced.
+- Names propagate through type aliases.
 
 ### Usage and Examples:
 
@@ -107,9 +110,9 @@ type E = () -> (num: number) -- valid!
 ```
 
 ```luau
-type Foo_2<A, T...> = (A, T...) -> ()
-type B = Foo_2<string, (x: number, y: number)> -- valid, T... is a type pack, A is not
-type B = Foo_2<(text: string), (x: number, y: number)> -- not valid "A", is not a type pack
+type Mixed<A, T...> = (A, T...) -> ()
+type B = Mixed<string, (x: number, y: number)> -- valid, T... is a type pack, A is not
+type B = Mixed<(text: string), (x: number, y: number)> -- not valid "A", is not a type pack
 ```
 
 <br/>
@@ -127,7 +130,7 @@ type MySignal = WrappedSignal<(amount: number, message: string)>
 ]]
 ```
 
-Nothing changes about the types own identity, it just gets associated with metadata.
+
 
 <br/>
 
@@ -146,9 +149,10 @@ end
 ## Drawbacks
 
 - Most likely none, other than the implementation.
+- Union or intersections may keep a random name.
 
 
-We can't rename ``T`` here
+This RFC doesn't solve that we can't rename ``T`` here.
 ```luau
 type Foo<T> = (arg: T) -> ()
 type A = Foo<(x: number)> -- (x: number), does not count as a type pack
@@ -161,7 +165,7 @@ local e: Bar<(x: number, y: number)>
 
 ## Alternatives
 
-- A new syntax where it would be ``[x: number, y: number, z: number]`` or ``[x: number], [y: number], [z: number]``
+- A new syntax where it would be ``[x: number, y: number, z: number]`` or ``[x: number], [y: number], [z: number]``, that can be applied into types directly, other than within the type pack.
 <br/>
 
 - Type functions could expose modifying argument names, but that would only work for function annotations, not on a type alone.

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -71,13 +71,12 @@ And currently, there isn't a way to provide a name/label when using ``Callback<T
 
 The idea is to allow to describe names in any valid type pack context.
 
-e.g. allowing you to do ``Type<(x: number)>`` if ``Type<T...>`` without being exclusively restricted to function annotations anymore.
+Allowing you to do ``Type<(x: number)>`` if the base is ``Type<T...>`` without being exclusively restricted to function annotations anymore.
 
 Names/Labels are only metadata:
 - Names/Labels are NOT enforced in any type checking way
 - They don't affect the type itself
 - They only improve front-end hints
-
 
 ### Usage and Examples:
 
@@ -88,18 +87,22 @@ function Foo(cb: Callback<(targetBar: Bar)> end
 -- cb shows (targetBar: Bar) -> ()
 ```
 
+```luau
+type Bar<T> = (T) -> ()
+type A = Bar<(num: number)> -- not valid (T) is not a type pack!
+type MyNumber = (num: number) -- not valid not a type pack!
+```
 
 
 ```luau
 type Foo<T...> = (T...) -> ()
-type Bar<T> = (T) -> ()
 
 type A = Foo<(a: number, number, label: number)> -- allowed
 type B = Foo<(x: number), (y: number)> -- not valid
 type C = Foo<(x: number, y: number)> -- valid
 
-type D = (num: number) -> () -- Already works in Luau, no changes!
-type E = Bar<(num: number)> -- not valid because no type pack here!
+type D = (num: number) -> () -- already works in Luau, no changes!
+type E = () -> (num: number) -- valid!
 ```
 
 <br/>
@@ -123,7 +126,6 @@ Nothing changes about the types own identity, it just gets associated with metad
 
 
 ```luau
-type MyNumber = (x: number)
 type Func = () -> (x: number, y: number, z: number)
 function Func2(): (a: number, b: number, c: number)
   return 1,2,3

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -105,6 +105,7 @@ type B = Foo<(x: number), (y: number)> -- not valid
 type C = Foo<(x: number, y: number)> -- valid
 
 type D = (num: number) -> () -- Already works in Luau, no changes!
+type E = Bar<(num: number)> -- not valid because no type pack here!
 ```
 
 <br/>

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -145,7 +145,7 @@ type C = Foo_2<(x: number)> -- same here for "arg"
 ## Drawbacks
 
 - Most likely none, other than the implementation.
-- Whether argument names
+- Whether ``(arg: T)`` should have ``"arg"`` replaced or not, if substituted by ``(x: number)``.
 
 
 ## Alternatives

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -135,7 +135,7 @@ In the event where an annotation already has a name. The name would get overwrit
 type Foo<T...> = (args: T...) -> ()
 type Foo_2<T> = (arg: T) -> ()
 
-type A = Foo<(number, number)> -- nothing changes
+type A = Foo<(number, number)> -- nothing changes about "args"
 type A = Foo<(x: number, y: number)> -- "args" would be gone if something substituted a generic
 type C = Foo_2<(x: number)> -- same here for "arg"
 ```

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -141,8 +141,9 @@ type Func = () -> (x: number, y: number, z: number)
 ## Alternatives
 
 - A new syntax where it would be ``[x: number, y: number, z: number]`` or ``[x: number], [y: number], [z: number]``
+<br/>
 
-Type functions could expose modifying argument names, but that would only work for function annotations, not on a type alone.
+- Type functions could expose modifying argument names, but that would only work for function annotations, not on a type alone.
 There wouldn't be a way to attach a label to a type.
 
 ```luau
@@ -152,7 +153,7 @@ type MySignal = WrappedSignal<(label1: number, label2: string) -> ()>
 And this would also mean that ``WrappedSignal`` needs to implement a type function now, that takes out the argument names and transforms ``.FireToFoo``.
 And that sounds too complicated.
 
-You don't want it to be
 
-You want it to be ``( targetFoo: Foo: Player, (label1: number, label2: string) -> () ) -> ()``
-you want ``(targetFoo: Foo: Player, label1: number, label2: string) -> ()``.
+You don't want it to be ``( targetFoo: Foo: Player, (label1: number, label2: string) -> () ) -> ()``
+
+You want ``(targetFoo: Foo: Player, label1: number, label2: string) -> ()``.

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -133,11 +133,11 @@ type Func = () -> (x: number, y: number, z: number)
 In the event where an annotation already has a name. The name would get overwritten if...
 ```luau
 type Foo<T...> = (args: T...) -> ()
-type Bar<T> = (arg: T) -> ()
+type Foo_2<T> = (arg: T) -> ()
 
 type A = Foo<(number, number)> -- nothing changes
-type B = Foo<(x: number, y: number)> -- "args" would be gone if something substituted a generic
-type C = Foo<(x: number)> -- same here for "arg
+type A = Foo<(x: number, y: number)> -- "args" would be gone if something substituted a generic
+type C = Foo_2<(x: number)> -- same here for "arg"
 ```
 
 
@@ -145,9 +145,7 @@ type C = Foo<(x: number)> -- same here for "arg
 ## Drawbacks
 
 - Most likely none, other than the implementation.
-
-- We have to ask ourselves what would happen to this
-
+- Whether argument names
 
 
 ## Alternatives

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -130,12 +130,24 @@ type MyNumber = (x: number)
 type Func = () -> (x: number, y: number, z: number)
 ```
 
+In the event where an annotation already has a name. The name would get overwritten if...
+```luau
+type Foo<T...> = (args: T...) -> ()
+type Bar<T> = (arg: T) -> ()
+
+type A = Foo<(number, number)> -- nothing changes
+type B = Foo<(x: number, y: number)> -- "args" would be gone if something substituted a generic
+type C = Foo<(x: number)> -- same here for "arg
+```
 
 
 
 ## Drawbacks
 
 - Most likely none, other than the implementation.
+
+- We have to ask ourselves what would happen to this
+
 
 
 ## Alternatives

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -94,12 +94,15 @@ function Foo(cb: Callback<(targetBar: Bar)> end
 -- cb shows (targetBar: Bar) -> ()
 ```
 
+
+
 ```luau
 type Foo<T...> = (T...) -> ()
 type Bar<T> = (T) -> ()
 
 type A = Foo<(a: number, number, label: number)> -- allowed
-type B = Foo<(x: number), (y: number)> -- allowed
+type B = Foo<(x: number), (y: number)> -- not valid
+type B = Foo<(x: number, y: number)> -- valid
 
 type C = Bar<(x: number, y: number)> -- Error: More than one type!
 type D = (num: number) -> () -- Already works in Luau, no changes!
@@ -141,6 +144,7 @@ type A = Foo<(x: number)> -- "arg" stays.
 type Foo<T> = (T) -> ()
 type A = Foo<(x: number)> -- "T" had no name, so it gets given one!
 ```
+
 
 
 

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -145,7 +145,6 @@ end
 ## Drawbacks
 
 - Most likely none, other than the implementation.
-- Whether ``(arg: T)`` should have ``"arg"`` replaced or not, if substituted by ``(x: number)``.
 
 
 We can't rename ``T`` here

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -45,7 +45,7 @@ But in this case, the result of ``MySignal.FireToFoo`` would show up as:
 -- or
 (self: WrappedSignal<T...>, targetFoo: Foo, number, string)
 ```
-without any context or indication on what these provided types ``(number, string)`` are meant to re-present.
+without any context or indication on what these provided types ``(number, string)`` are meant to represent.
 
 But you can see that ``targetFoo: Foo`` is present, but only because function annotations specifically let you describe argument names, which APIs can pick-up on.
 

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -102,9 +102,8 @@ type Bar<T> = (T) -> ()
 
 type A = Foo<(a: number, number, label: number)> -- allowed
 type B = Foo<(x: number), (y: number)> -- not valid
-type B = Foo<(x: number, y: number)> -- valid
+type C = Foo<(x: number, y: number)> -- valid
 
-type C = Bar<(x: number, y: number)> -- Error: More than one type!
 type D = (num: number) -> () -- Already works in Luau, no changes!
 ```
 
@@ -150,6 +149,10 @@ We can't rename ``T`` here
 ```luau
 type Foo<T> = (arg: T) -> ()
 type A = Foo<(x: number)> -- (x: number), does not count as a type pack
+
+-- Not possible!
+type Bar<T,U> = (T,U) -> ()
+local e: Bar<(x: number, y: number)>
 ```
 
 

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -105,6 +105,12 @@ type D = (num: number) -> () -- already works in Luau, no changes!
 type E = () -> (num: number) -- valid!
 ```
 
+```luau
+type Foo_2<A, T...> = (A, T...) -> ()
+type B = Foo_2<string, (x: number, y: number)> -- valid, T... is a type pack, A is not
+type B = Foo_2<(text: string), (x: number, y: number)> -- not valid "A", is not a type pack
+```
+
 <br/>
 
 ```luau

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -102,6 +102,7 @@ type A = Foo<(a: number, number, label: number)> -- allowed
 type B = Foo<(x: number), (y: number)> -- allowed
 
 type C = Bar<(x: number, y: number)> -- Error: More than one type!
+type D = (num: number) -> () -- Already works in Luau, no changes!
 ```
 
 <br/>

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -78,7 +78,7 @@ Names/Labels are only metadata:
 - They don't affect the type itself
 - They only improve front-end hints
 - Nothing changes about the types own identity, it just gets associated with a name.
-- The name is NOT forced.
+- The name is NOT forced and are completely optional.
 - Names propagate through type aliases.
 
 ### Usage and Examples:

--- a/docs/type-pack-names.md
+++ b/docs/type-pack-names.md
@@ -133,14 +133,13 @@ function Func2(): (a: number, b: number, c: number)
 end
 ```
 
-In the event where an annotation already has a name. The name would get overwritten if...
+In the event where an annotation already has a name, we will keep the name if possible.
 ```luau
-type Foo<T...> = (args: T...) -> ()
-type Foo_2<T> = (arg: T) -> ()
+type Foo<T> = (arg: T) -> ()
+type A = Foo<(x: number)> -- "arg" stays.
 
-type A = Foo<(number, number)> -- nothing changes about "args"
-type A = Foo<(x: number, y: number)> -- "args" would be gone if something substituted a generic
-type C = Foo_2<(x: number)> -- same here for "arg"
+type Foo<T> = (T) -> ()
+type A = Foo<(x: number)> -- "T" had no name, so it gets given one!
 ```
 
 


### PR DESCRIPTION
[Rendered](https://github.com/karl-police/rfcs/blob/patch-4/docs/type-pack-names.md)

