### PR TITLE
Reserve `@self` require alias to prevent user-defined overrides

### DIFF
--- a/docs/abstract-module-paths-and-init-dot-luau.md
+++ b/docs/abstract-module-paths-and-init-dot-luau.md
@@ -97,6 +97,7 @@ module.
 
 We propose to alleviate this with a special import alias `@self` that resolves
 to the path to the current module.
+This alias is reserved and cannot be overridden by user-defined alias mappings.
 
 ```lua
 -- package/init.luau


### PR DESCRIPTION
In #109, I had initially [proposed](https://github.com/luau-lang/rfcs/pull/109#issuecomment-2759143342) that we allow users to override `@self` in their user-defined alias maps, as the semantics would then be similar to how the `script` global in Roblox scripts could be shadowed. We didn't want to encourage this pattern, but I didn't really see any harm at the time.

Over a year later, we have now exposed generalized `require` semantics through the `Luau.Require` library, and I've realized we made the wrong move (oops!). Using `@self` is turning out to be extremely common, both for code that runs in filesystem-targeting runtimes (e.g. Lute) and even in Roblox (e.g. Roblox's own [Character Controller Library](https://create.roblox.com/docs/characters/character-controller-library)).

By allowing `@self` to be overridden, the generalized require resolver is forced to check all parent directories for a user-defined `@self` alias before proceeding with navigation, which is horrible for performance. If we forbid user-defined overrides of `@self`, we can immediately continue on with path navigation without this unnecessary cost.

Although we discussed these two options in the original RFC comments, it turns out nothing was ever cemented in the RFC document itself. In this PR, I've spelled these semantics out explicitly.

Backwards-compatibility: if anyone is currently overriding `@self`, this will be a breaking change. I think this is an acceptable cost for a few reasons:
- I doubt anyone is actually doing this.
- If someone is doing it, there is a migration path (change the alias name to something else).
- The `@self` alias is the most commonly used alias today, and we should be optimizing for the common use case.