### PR TITLE
type syntax subtype matching (draft)

### DIFF
--- a/docs/syntax-type-subtype-matching-manifesto.md
+++ b/docs/syntax-type-subtype-matching-manifesto.md
@@ -64,13 +64,14 @@ closing questions (draft, temporary):
 infer these types usefully?
   - the answer is, in narrow circumstances, almost certainly:
   ```luau
+  -- the type system could resolve this annotation all on its own
   local result: match (
   	typeof(foo)
   ) {
   	(~false?): typeof(bar),
   	(false?): typeof(baz),
   	(): typeof(bar) | typeof(baz),
-  }
+  } = if foo then bar else baz
   ```
 - could the type system infer generic bounds from match syntax?
   - probably yes, any arm which returns `never`(s) could constrain input types

--- a/docs/syntax-type-subtype-matching-manifesto.md
+++ b/docs/syntax-type-subtype-matching-manifesto.md
@@ -35,10 +35,17 @@ ourselves to matches testable at runtime
 rough syntax declaration:
 
 ```luau
+-- a very simple example
+local function meow<bool>(): match (bool) {
+	(true): some_value,
+	(false): nil,
+	(boolean): some_value?,
+	(): never, -- this is the default final arm, defined explicitly for this example
+}
+end
 -- i think we should probably require parenthesis on the pack here because it looks the most luau and also wont block
 -- t {} type syntax from happening in the future
 -- the first matching arm will be the output of this type function
--- match syntax will be allowed more or less anywhere a type is allowed
 type retrieve<entity, lifetime, dead> = match (lifetime, dead) {
 	-- similarly to functions, parenthesis are required on the input pack but not the output pack.
 	-- to avoid confusion with function types, ':' has been chosen as a separator between the input and output packs.
@@ -46,7 +53,6 @@ type retrieve<entity, lifetime, dead> = match (lifetime, dead) {
 	("static"): index<entity, "data">,
 	("dynamic", true): nil,
 	-- trailing commas or semicolons are allowed
-	-- '(): never' will be the final arm by default unless specified
 	(): index<entity, "data">?,
 }
 ```
@@ -58,6 +64,7 @@ to rely on subtyping. is there a more intuitive way to handle issues with covari
 - is there any other surprising (bad) behavior these packs will exhibit with existing subtyping rules?
 - can type inference construct matches? if no, and if runtime matching were to ever exist, could type inference then
 infer these types usefully?
+- could the type system infer generic bounds from match syntax?
 - will this mesh with type pack unions?
 
 ## drawbacks

--- a/docs/syntax-type-subtype-matching-manifesto.md
+++ b/docs/syntax-type-subtype-matching-manifesto.md
@@ -19,7 +19,7 @@ types, and user experience. this rfc aims to:
 - enable an expeditious implementation timeline with good room for improvement from type pack functions & native support
 - make cohesive type-level programming patterns more idiomatic to improve user experience and adoption within luau's new
 type solver
-- provide major performance benefits over traditional function overloads due to the linear priority and 
+- provide major performance benefits over traditional function overloads via linear shortcircuiting
 
 ## design
 
@@ -31,8 +31,6 @@ respecting covariance. a built-in implementation could improve performance & inf
 formalizing this, but it does not need to exist at first.
 - runtime match expressions are intentionally out of scope for this rfc, and it seems like a bad choice to limit
 ourselves to matches testable at runtime
-- shortcircuiting should have major performance advantages over traditional overloading because the priority is clear,
-and you don't need to check the validity of every arm.
 
 rough syntax declaration:
 

--- a/docs/syntax-type-subtype-matching-manifesto.md
+++ b/docs/syntax-type-subtype-matching-manifesto.md
@@ -20,7 +20,7 @@ types, and user experience. this rfc aims to:
 - make cohesive type-level programming patterns more idiomatic to improve user experience and adoption within luau's new
 type solver
 - use match syntax to improve verifiability and inference of programs with complex type expression
-- provide major performance benefits over traditional function overloads via linear shortcircuiting
+- provide major performance benefits over traditional function overloads and type functions
 
 ## design
 
@@ -59,9 +59,7 @@ type retrieve<entity, lifetime, dead> = match (lifetime, dead) {
 ```
 
 closing questions (draft, temporary):
-- if we implement this with current subtyping rules respecting covariance, users may shoot themselves in the foot with
-inexact tables. this issue exists already when using the type system, but will likely surface more if we encourage users
-to rely on subtyping. is there a more intuitive way to handle issues with covariance here?
+- if we implement this with current subtyping rules respecting variance, users may shoot themselves in the foot with inexact types. this issue exists already when using the type system, but will likely surface more if we encourage users to rely on subtyping. is there a more intuitive way to handle issues here?
 - is there any other surprising (bad) behavior these packs will exhibit with existing subtyping rules?
 - can type inference construct matches? if no, and if runtime matching were to ever exist, could type inference then
 infer these types usefully?
@@ -77,10 +75,9 @@ infer these types usefully?
   ```
 - could the type system infer generic bounds from match syntax?
   - probably yes, any arm which returns `never`(s) could constrain input types
-  - this begs the question, there may be branches where you want to explicitly emit a user-defined type error. Should we
+  - there may be branches where you want to explicitly emit a user-defined type error. Should we
   add discrete syntax to surface specific errors and 'explanations' from matches?
-- can the type system verify returns with match types? if no, is runtime matching a prerequisite to implementing this
-rfc?
+- can the type system verify returns with match types?
   - it seems likely it could be far superior to existing function overloads. i'm currently unsure how much flexibility
   there is with the soundness and completeness of that tho
 - will this mesh with type pack unions?
@@ -89,7 +86,7 @@ rfc?
 
 todo
 - users may be encouraged to test subtyping against larger types when a simpler discriminant can be used trivially
-- although the simplicity of making this sugard around user-defined type functions is advantageous, we should consider:
+- although the simplicity of making this sugar around user-defined type functions is advantageous, we should consider:
   - implementing it with a type function means non-unary return packs will need to be a type error until type pack
   functions are done
   - user-defined type functions might not have imperative access to match types

--- a/docs/syntax-type-subtype-matching-manifesto.md
+++ b/docs/syntax-type-subtype-matching-manifesto.md
@@ -19,6 +19,7 @@ types, and user experience. this rfc aims to:
 - enable an expeditious implementation timeline with good room for improvement from type pack functions & native support
 - make cohesive type-level programming patterns more idiomatic to improve user experience and adoption within luau's new
 type solver
+- use match syntax to improve verifiability and inference of programs with complex type expression
 - provide major performance benefits over traditional function overloads via linear shortcircuiting
 
 ## design
@@ -75,11 +76,13 @@ infer these types usefully?
   }
   ```
 - could the type system infer generic bounds from match syntax?
-  - probably yes, any arm which returns `never`(s) could be used to constrain types
+  - probably yes, any arm which returns `never`(s) could constrain input types
   - this begs the question, there may be branches where you want to explicitly emit a user-defined type error. Should we
-  add complementary syntax to support that?
+  add discrete syntax to surface specific errors and 'explanations' from matches?
 - can the type system verify returns with match types? if no, is runtime matching a prerequisite to implementing this
 rfc?
+  - it seems likely it could be far superior to existing function overloads. i'm currently unsure how much flexibility
+  there is with the soundness and completeness of that tho
 - will this mesh with type pack unions?
 
 ## drawbacks

--- a/docs/syntax-type-subtype-matching-manifesto.md
+++ b/docs/syntax-type-subtype-matching-manifesto.md
@@ -17,10 +17,10 @@ those of [user-defined type functions](https://rfcs.luau.org/user-defined-type-f
 types, and user experience. this rfc aims to:
 - use simple syntax to complement existing traits found in user defined type functions
 - enable an expeditious implementation timeline with good room for improvement from type pack functions & native support
-- make cohesive type-level programming patterns more idiomatic to improve user experience and adoption within luau's new
+- make type-level programming patterns more idiomatic to improve user experience and adoption within luau's new
 type solver
 - use match syntax to improve verifiability and inference of programs with complex type expression
-- provide major performance benefits over traditional function overloads and type functions
+- provide major editor performance benefits over traditional function overloads and type functions
 
 ## design
 
@@ -28,7 +28,7 @@ this section is incomplete and serves as a rough draft of what the design might 
 
 some personal notes:
 - i think we should implement this initially as syntactic sugar around type functions and subtyping, of course
-respecting covariance. a built-in implementation could improve performance & inference a lot, which is a goal of
+respecting variance. a built-in implementation could improve performance & inference a lot, which is a goal of
 formalizing this, but it does not need to exist at first.
 - runtime match expressions are intentionally out of scope for this rfc, and it seems like a bad choice to limit
 ourselves to matches testable at runtime
@@ -59,7 +59,6 @@ type retrieve<entity, lifetime, dead> = match (lifetime, dead) {
 ```
 
 closing questions (draft, temporary):
-- if we implement this with current subtyping rules respecting variance, users may shoot themselves in the foot with inexact types. this issue exists already when using the type system, but will likely surface more if we encourage users to rely on subtyping. is there a more intuitive way to handle issues here?
 - is there any other surprising (bad) behavior these packs will exhibit with existing subtyping rules?
 - can type inference construct matches? if no, and if runtime matching were to ever exist, could type inference then
 infer these types usefully?
@@ -86,6 +85,7 @@ infer these types usefully?
 
 todo
 - users may be encouraged to test subtyping against larger types when a simpler discriminant can be used trivially
+- users might expect covariance when their match expressions search for e.g. `{ unknown }`. subtyping issues like this exist today, but will surface more if we encourage logic based on subtyping
 - although the simplicity of making this sugar around user-defined type functions is advantageous, we should consider:
   - implementing it with a type function means non-unary return packs will need to be a type error until type pack
   functions are done

--- a/docs/syntax-type-subtype-matching-manifesto.md
+++ b/docs/syntax-type-subtype-matching-manifesto.md
@@ -36,6 +36,7 @@ rough syntax declaration:
 
 ```luau
 -- a very simple example
+-- the first matching arm will be the output of this function
 local function meow<bool>(): match (bool) {
 	(true): some_value,
 	(false): nil,
@@ -45,7 +46,6 @@ local function meow<bool>(): match (bool) {
 end
 -- i think we should probably require parenthesis on the pack here because it looks the most luau and also wont block
 -- t {} type syntax from happening in the future
--- the first matching arm will be the output of this type function
 type retrieve<entity, lifetime, dead> = match (lifetime, dead) {
 	-- similarly to functions, parenthesis are required on the input pack but not the output pack.
 	-- to avoid confusion with function types, ':' has been chosen as a separator between the input and output packs.

--- a/docs/syntax-type-subtype-matching-manifesto.md
+++ b/docs/syntax-type-subtype-matching-manifesto.md
@@ -40,6 +40,7 @@ rough syntax declaration:
 -- i think we should probably require parenthesis on the pack here because it looks the most luau and also wont block
 -- t {} type syntax from happening in the future
 -- the first matching arm will be the output of this type function
+-- match syntax will be allowed more or less anywhere a type is allowed
 type retrieve<entity, lifetime, dead> = match (lifetime, dead) {
 	-- similarly to functions, parenthesis are required on the input pack but not the output pack.
 	-- to avoid confusion with function types, ':' has been chosen as a separator between the input and output packs.

--- a/docs/syntax-type-subtype-matching-manifesto.md
+++ b/docs/syntax-type-subtype-matching-manifesto.md
@@ -64,9 +64,22 @@ to rely on subtyping. is there a more intuitive way to handle issues with covari
 - is there any other surprising (bad) behavior these packs will exhibit with existing subtyping rules?
 - can type inference construct matches? if no, and if runtime matching were to ever exist, could type inference then
 infer these types usefully?
+  - the answer is, in narrow circumstances, almost certainly:
+  ```luau
+  local result: match (
+  	typeof(foo)
+  ) {
+  	(~false?): typeof(bar),
+  	(false?): typeof(baz),
+  	(): typeof(bar) | typeof(baz),
+  }
+  ```
 - can the type system verify returns with match types? if no, is runtime matching a prerequisite to implementing this
 rfc?
 - could the type system infer generic bounds from match syntax?
+  - probably yes, any arm which returns `never`(s) could be used to constrain types
+  - this begs the question, there may be branches where you want to explicitly emit a user-defined type error. Should we
+  add complementary syntax to support that?
 - will this mesh with type pack unions?
 
 ## drawbacks

--- a/docs/syntax-type-subtype-matching-manifesto.md
+++ b/docs/syntax-type-subtype-matching-manifesto.md
@@ -74,12 +74,12 @@ infer these types usefully?
   	(): typeof(bar) | typeof(baz),
   }
   ```
-- can the type system verify returns with match types? if no, is runtime matching a prerequisite to implementing this
-rfc?
 - could the type system infer generic bounds from match syntax?
   - probably yes, any arm which returns `never`(s) could be used to constrain types
   - this begs the question, there may be branches where you want to explicitly emit a user-defined type error. Should we
   add complementary syntax to support that?
+- can the type system verify returns with match types? if no, is runtime matching a prerequisite to implementing this
+rfc?
 - will this mesh with type pack unions?
 
 ## drawbacks

--- a/docs/syntax-type-subtype-matching-manifesto.md
+++ b/docs/syntax-type-subtype-matching-manifesto.md
@@ -1,0 +1,76 @@
+# introduce type subtype matching syntax
+
+## unfinalized
+
+this rfc is a draft not intended to be merged as-is. after getting feedback on initial ideas,
+design / drawbacks / alternatives will be refined & completed fully.
+
+## summary
+
+introduces syntax to construct a type function which branches on subtyping of a type pack, acting as a strong
+alternative to traditional methods of overloading type signatures.
+
+## motivation
+
+any first-class support for programmatic concepts (such as control flow) in the type system carry similar benefits to
+those of [user-defined type functions](https://rfcs.luau.org/user-defined-type-functions.html) in precision, synthetic
+types, and user experience. this rfc aims to:
+- use simple syntax to complement existing traits found in user defined type functions
+- enable an expeditious implementation timeline with good room for improvement from type pack functions & native support
+- make cohesive type-level programming patterns more idiomatic to improve user experience and adoption within luau's new
+type solver
+- provide major performance benefits over traditional function overloads due to the linear priority and 
+
+## design
+
+this section is incomplete and serves as a rough draft of what the design might look like
+
+some personal notes:
+- i think we should implement this initially as syntactic sugar around type functions and subtyping, of course
+respecting covariance. a built-in implementation could improve performance & inference a lot, which is a goal of
+formalizing this, but it does not need to exist at first.
+- runtime match expressions are intentionally out of scope for this rfc, and it seems like a bad choice to limit
+ourselves to matches testable at runtime
+- shortcircuiting should have major performance advantages over traditional overloading because the priority is clear,
+and you don't need to check the validity of every arm.
+
+rough syntax declaration:
+
+```luau
+-- i think we should probably require parenthesis on the pack here because it looks the most luau and also wont block
+-- t {} type syntax from happening in the future
+-- the first matching arm will be the output of this type function
+type retrieve<entity, lifetime, dead> = match (lifetime, dead) {
+	-- similarly to functions, parenthesis are required on the input pack but not the output pack.
+	-- to avoid confusion with function types, ':' has been chosen as a separator between the input and output packs.
+	-- we'll append an implicit ...any to the tail of this pack so it doesn't need to be written by hand
+	("static"): index<entity, "data">,
+	("dynamic", true): nil,
+	-- trailing commas or semicolons are allowed
+	-- '(): never' will be the final arm by default unless specified
+	(): index<entity, "data">?,
+}
+```
+
+closing questions (draft, temporary):
+- if we implement this with current subtyping rules respecting covariance, users may shoot themselves in the foot with
+inexact tables. this issue exists already when using the type system, but will likely surface more if we encourage users
+to rely on subtyping. is there a more intuitive way to handle issues with covariance here?
+- is there any other surprising (bad) behavior these packs will exhibit with existing subtyping rules?
+- can type inference construct matches? if no, and if runtime matching were to ever exist, could type inference then
+infer these types usefully?
+- will this mesh with type pack unions?
+
+## drawbacks
+
+todo
+- users may be encouraged to test subtyping against larger types when a simpler discriminant can be used trivially
+- although the simplicity of making this sugard around user-defined type functions is advantageous, we should consider:
+  - implementing it with a type function means non-unary return packs will need to be a type error until type pack
+  functions are done
+  - user-defined type functions might not have imperative access to match types
+- todo...
+
+## alternatives
+
+- todo

--- a/docs/syntax-type-subtype-matching-manifesto.md
+++ b/docs/syntax-type-subtype-matching-manifesto.md
@@ -64,6 +64,8 @@ to rely on subtyping. is there a more intuitive way to handle issues with covari
 - is there any other surprising (bad) behavior these packs will exhibit with existing subtyping rules?
 - can type inference construct matches? if no, and if runtime matching were to ever exist, could type inference then
 infer these types usefully?
+- can the type system verify returns with match types? if no, is runtime matching a prerequisite to implementing this
+rfc?
 - could the type system infer generic bounds from match syntax?
 - will this mesh with type pack unions?
 


### PR DESCRIPTION
[rendered](https://github.com/nnullcolumn/luau-lang-rfcs/blob/syntax-type-subtype-matching/docs/syntax-type-subtype-matching-manifesto.md).