### PR TITLE
Error handling support for user-defined type functions

### DIFF
--- a/docs/user-defined-type-functions.md
+++ b/docs/user-defined-type-functions.md
@@ -77,6 +77,7 @@ The type functions will run in a sandboxed VM instance with a limited scope of a
 - `assert`, `error`, and `print`, which will be used by type functions to provide error feedback to consumers of a type function
 - `next`, `ipairs`, `pairs`, `select`, and `unpack`, which support basic iteration and interaction with tables and multiple return
 - `getmetatable`, `setmetable`, `rawget`, `rawset`, `rawlen`, `rawequal`, `tonumber`, `tostring`, `type`, and `typeof`, which are builtin functions that are essentially operators in Luau
+- `pcall` and `xpcall`, necessary for error handling
 - the `math` library, where we note that `math.randomseed` will be reset automatically on type function entry
 - the `table` library
 - the `string` library


### PR DESCRIPTION
Making this RFC in a form of an amendment to original RFC.

`pcall` and `xpcall` are essential functions for error handling in Luau.

Given that built-in library functions as well as `type` methods and `types` library can all error, it will be helpful if those errors can be handled within.
It will also enable developers to use errors internally if they prefer that over returning status codes for error conditions.

I was unable to think of downsides in terms of safety, deprecation or performance, to continue excluding these from the type function environment.
