### PR TITLE
[meta] Add a `Prior Art` section to the RFC template

### DIFF
--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -19,3 +19,8 @@ Why should we *not* do this?
 ## Alternatives
 
 What other designs have been considered? What is the impact of not doing this?
+
+# Prior Art
+
+* Do other programming languages have similar features? What do those look like? How do they compare and contrast to this design? 
+* What supporting features do those languages have that might _not_ be included in this design?

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -20,7 +20,7 @@ Why should we *not* do this?
 
 What other designs have been considered? What is the impact of not doing this?
 
-# Prior Art
+## Prior Art
 
 * Do other programming languages have similar features? What do those look like? How do they compare and contrast to this design? 
 * What supporting features do those languages have that might _not_ be included in this design?

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -24,3 +24,4 @@ What other designs have been considered? What is the impact of not doing this?
 
 * Do other programming languages have similar features? What do those look like? How do they compare and contrast to this design? 
 * What supporting features do those languages have that might _not_ be included in this design?
+* Are there other similar features or libraries in Luau already? How does this feature align with _those_ features in terms of naming, syntax, and semantics?

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -22,6 +22,6 @@ What other designs have been considered? What is the impact of not doing this?
 
 ## Prior Art
 
-* Do other programming languages have similar features? What do those look like? How do they compare and contrast to this design? 
-* What supporting features do those languages have that might _not_ be included in this design?
-* Are there other similar features or libraries in Luau already? How does this feature align with _those_ features in terms of naming, syntax, and semantics?
+* Do other programming languages have similar features? What do those look like? How do they compare and contrast to this design? Are there unique constraints for Luau that interact with said design?
+* What supporting features do those languages have that might _not_ be included in this design? If we're adding something feature A, are there features B, C, and D that are often used with A?
+* Are there other similar features or libraries in Luau already? How does this feature align with _those_ features in terms of naming, syntax, and/or semantics?


### PR DESCRIPTION
Like most engineering, language design heavily benefits from looking at prior art, and the _vast_ majority of language features have prior art in a widely used programming language:
- Having similar features look and behave similarly helps widen the pit of success: it's good that a `while` loop in Luau and one in JavaScript work roughly the same.
- You can dodge known pitfalls with commonly implemented features: as of this writing we are using other implementations of classes to prove out the design for classes in Luau.
- Other languages with extensive RFC processes can provide hints and reasoning for direction on _our_ RFCs, [for example the FAQ about why Javascript uses the `#` sigil to mean `private`](https://github.com/tc39/proposal-class-fields/blob/f372de4f4f5a245203fbb6cf5b461ed62d34e27c/PRIVATE_SYNTAX_FAQ.md#whats-this-about-).

This can also apply to prior art for library functions. If we're adding a new `math` function, do other languages standard libraries have the same functions? The same constants?

This is worth adding a section to push _all_ RFC writers in the right direction.