### PR TITLE
Expose Built-in Type Functions to User-Defined Type Functions 

### DIFF
--- a/docs/expose-builtin-typefunctions-to-udtf.md
+++ b/docs/expose-builtin-typefunctions-to-udtf.md
@@ -44,7 +44,8 @@ type foo = ultra_negate<negatable_string> -- 'foo' resolves to '~string'
 
 * Let users write aliases for the built-in type functions the way it currently can be done.
 
-* Only expose certain built-in type functions *selectively*, instead of exposing all public-facing ones. This would allow superseded built-in type functions like `setmetatable` to be omitted entirely, and also allow other built-ins like `lt` to be renamed to `lessthan`, thus making `types.*` be a more viable alternative to `types.builtins.*`.
+* Only expose certain built-in type functions *selectively*, instead of exposing all public-facing ones. This would allow superseded built-in type functions like `setmetatable` to be omitted entirely.
+	* This alternative could also lead to other built-ins like `lt` to be renamed to `lessthan`, thus making `types.*` be a more viable alternative to `types.builtins.*`.
 
 ### Namespace Alternatives
 

--- a/docs/expose-builtin-typefunctions-to-udtf.md
+++ b/docs/expose-builtin-typefunctions-to-udtf.md
@@ -45,22 +45,17 @@ type foo = ultra_negate<negatable_string> -- 'foo' resolves to '~string'
 
 ### Namespace Alternatives
 
-> Dump all built-in type functions into the global namespace
+* Dump all built-in type functions into the global namespace
+* * This would be highly undesirable, since now the global namespace is polluted with both value and type functions. And certain labels would clash with already existing labels like `rawget`.
 
-This would be highly undesirable, since now the global namespace is polluted with both value and type functions. And certain labels would clash with already existing labels like `rawget`.
+* `types.*`, '*' being the built-in name
+* * While this might feel right for some; for others, names like `lt` and `unm` might feel off next to verbose (but concise) names like `intersectionof` and `newfunction`.
 
-> `types.*`, '*' being the built-in name
+* `types.typefunctions.*`
+* * The name `types.builtins` might not indicate that it contains built-in type functions specifically, this alternative could alleviate this issue. Although some may consider it too-verbose.
 
-While this might feel right for some; for others, names like `lt` and `unm` might feel off next to verbose (but concise) names like `intersectionof` and `newfunction`.
+* `typefunctions.*`
+* * This would fix the problem that comes with implementing `types.builtins` as there is no precedent in luau for such a thing. But the name `typefunctions` is rather ambigous whether it contains *all* type functions (UDTFs included) or rather just the built-in ones.
 
-> `types.typefunctions.*`
-
-The name `types.builtins` might not indicate that it contains built-in type functions specifically, this alternative could alleviate this issue. Although some may consider it too-verbose.
-
-> `typefunctions.*`
-
-This would fix the problem that comes with implementing `types.builtins` as there is no precedent in luau for such a thing. But the name `typefunctions` is rather ambigous whether it contains *all* type functions (UDTFs included) or rather just the built-in ones.
-
-> `builtintypefunctions.*`
-
-This fixes the ambiguity with `typefunctions` but is too verbose and the readability is questionable at best.
+* `builtintypefunctions.*`
+* * This fixes the ambiguity with `typefunctions` but is too verbose and the readability is questionable at best.

--- a/docs/expose-builtin-typefunctions-to-udtf.md
+++ b/docs/expose-builtin-typefunctions-to-udtf.md
@@ -1,0 +1,66 @@
+# Expose Built-in Type Functions to User-Defined Type Functions
+
+## Summary
+
+Exposes the built-in type functions present in luau such as `keyof` to the user-defined type function environment through the namespace `types.builtins`.
+
+## Motivation
+
+Currently, built-in type functions are not immediately accessible within the user-defined type function environment. This is not desired, as the built-in type functions provide utility such as `keyof` and `index`; and ways to handle operations between types with the likes of `add` and `unm`.
+
+Today, the way to circumvent this is to use boilerplate aliases such as `type proxy_keyof<T> = keyof<T>` to be able to use the built-in type functions; which, at a users glance, may seem erroneous for why these aren't readily available.
+
+## Design
+
+A new namespace called `builtins` under the `types` library is to be introduced. This namespace will contain all public-facing built-in type functions that are available.
+
+An example using `types.builtins`:
+```luau
+type function ultra_negate(t: type): type
+	return types.negationof(
+		types.builtins.unm(t) --applies the unary minus (-) operator to the type
+	)
+end
+
+type negatable_string = setmetatable<{}, {
+	__unm: (negatable_string) -> (string)
+}>
+
+type foo = ultra_negate<negatable_string> -- 'foo' resolves to '~string'
+```
+
+## Drawbacks
+
+* There is no precedent to add sub-namespaces to existing libraries in the luau standard library, such as `types.builtins` as this RFC proposes.
+
+* There is certain built-in type functions that might seem strange to see in the `types` library. One example would be the `setmetatable` built-in, since `tabletype:setmetatable` and `types.newtable`s `metatable` argument may supersede this built-in. Users might get confused or distracted trying to discern if it serves a different purpose behaviourally/semantically.
+
+* The name `types.builtins` does not indicate that it contains built-in *type functions* specifically.
+
+## Alternatives
+
+* Let users write aliases for the built-in type functions the way it currently can be done.
+
+* Only expose certain built-in type functions *selectively*, instead of exposing all public-facing ones. This would allow superseded built-in type functions like `setmetatable` to be omitted entirely, and also allow other built-ins like `lt` to be renamed to `lessthan`, thus making `types.*` be a more viable alternative to `types.builtins.*`.
+
+### Namespace Alternatives
+
+> Dump all built-in type functions into the global namespace
+
+This would be highly undesirable, since now the global namespace is polluted with both value and type functions. And certain labels would clash with already existing labels like `rawget`.
+
+> `types.*`, '*' being the built-in name
+
+While this might feel right for some; for others, names like `lt` and `unm` might feel off next to verbose (but concise) names like `intersectionof` and `newfunction`.
+
+> `types.typefunctions.*`
+
+The name `types.builtins` might not indicate that it contains built-in type functions specifically, this alternative could alleviate this issue. Although some may consider it too-verbose.
+
+> `typefunctions.*`
+
+This would fix the problem that comes with implementing `types.builtins` as there is no precedent in luau for such a thing. But the name `typefunctions` is rather ambigous whether it contains *all* type functions (UDTFs included) or rather just the built-in ones.
+
+> `builtintypefunctions.*`
+
+This fixes the ambiguity with `typefunctions` but is too verbose and the readability is questionable at best.

--- a/docs/expose-builtin-typefunctions-to-udtf.md
+++ b/docs/expose-builtin-typefunctions-to-udtf.md
@@ -46,16 +46,16 @@ type foo = ultra_negate<negatable_string> -- 'foo' resolves to '~string'
 ### Namespace Alternatives
 
 * Dump all built-in type functions into the global namespace
-* * This would be highly undesirable, since now the global namespace is polluted with both value and type functions. And certain labels would clash with already existing labels like `rawget`.
+	* This would be highly undesirable, since now the global namespace is polluted with both value and type functions. And certain labels would clash with already existing labels like `rawget`.
 
 * `types.*`, '*' being the built-in name
-* * While this might feel right for some; for others, names like `lt` and `unm` might feel off next to verbose (but concise) names like `intersectionof` and `newfunction`.
+	* While this might feel right for some; for others, names like `lt` and `unm` might feel off next to verbose (but concise) names like `intersectionof` and `newfunction`.
 
 * `types.typefunctions.*`
-* * The name `types.builtins` might not indicate that it contains built-in type functions specifically, this alternative could alleviate this issue. Although some may consider it too-verbose.
+	* The name `types.builtins` might not indicate that it contains built-in type functions specifically, this alternative could alleviate this issue. Although some may consider it too-verbose.
 
 * `typefunctions.*`
-* * This would fix the problem that comes with implementing `types.builtins` as there is no precedent in luau for such a thing. But the name `typefunctions` is rather ambigous whether it contains *all* type functions (UDTFs included) or rather just the built-in ones.
+	* This would fix the problem that comes with implementing `types.builtins` as there is no precedent in luau for such a thing. But the name `typefunctions` is rather ambigous whether it contains *all* type functions (UDTFs included) or rather just the built-in ones.
 
 * `builtintypefunctions.*`
-* * This fixes the ambiguity with `typefunctions` but is too verbose and the readability is questionable at best.
+	* This fixes the ambiguity with `typefunctions` but is too verbose and the readability is questionable at best.

--- a/docs/expose-builtin-typefunctions-to-udtf.md
+++ b/docs/expose-builtin-typefunctions-to-udtf.md
@@ -8,7 +8,7 @@ Exposes the built-in type functions present in Luau such as `keyof` to the user-
 
 Currently, built-in type functions are not immediately accessible within the user-defined type function environment. We would like to be able to use them because the built-in type functions include both utilities like `keyof` and `index`,  and functions to resolve the types of overloadable operators like `add` and `unm`.
 
-Since user-defined type aliases _are_ exposed to type functions, you can workaround the existing limitation by defining a new alias like `type aliasKeyOf<T> = keyof<T>`. However, we find this workaround to be unnecessarily cumbersome since it must be repeated in each module the user might define a type function using that builtin.
+Since user-defined type aliases _are_ exposed to type functions, you can workaround the existing limitation by defining a new alias like `type alias_keyof<T> = keyof<T>`. However, we find this workaround to be unnecessarily cumbersome since it must be repeated in each module the user might define a type function using that builtin.
 
 ## Design
 
@@ -29,7 +29,7 @@ type negatable_string = setmetatable<{}, {
 type foo = ultra_negate<negatable_string> -- 'foo' resolves to '~string'
 
 -- * this example previously would have needed to use an alias for 'unm' like seen below
--- type aliasUnm<T> = unm<T>
+-- type alias_unm<T> = unm<T>
 ```
 
 ## Drawbacks
@@ -53,7 +53,7 @@ type foo = ultra_negate<negatable_string> -- 'foo' resolves to '~string'
 
 * `types.*`, '*' being the built-in name
 	* This seems like the idiomatic alternative; although, names like `lt` and `unm` might feel off next to verbose (but concise) names like `intersectionof` and `newfunction`.
-	* Mixing built-in type functions directly into the `types` library might be undesirable, because the `types` library specifically contains type functions with _known_ return types. For example, when `types.optional` is used, the return type is guaranteed to be an `optionaltype`. In contrast, built-in type functions (especially those that resolve overloadable operators) can evaluate to _any_ arbitrary `type`.
+	* Mixing built-in type functions directly into the `types` library might be undesirable, because the `types` library specifically contains type functions with _known_ return types. For example, when `types.newtable` is used, the return type is guaranteed to be an `tabletype`. In contrast, built-in type functions (especially those that resolve overloadable operators) can evaluate to _any_ arbitrary `type`.
 
 * `types.typefunctions.*`
 	* The name `types.builtins` might not indicate that it contains built-in type functions specifically, this alternative could alleviate this issue. Although some may consider it too-verbose.

--- a/docs/expose-builtin-typefunctions-to-udtf.md
+++ b/docs/expose-builtin-typefunctions-to-udtf.md
@@ -2,17 +2,17 @@
 
 ## Summary
 
-Exposes the built-in type functions present in luau such as `keyof` to the user-defined type function environment through the namespace `types.builtins`.
+Exposes the built-in type functions present in Luau such as `keyof` to the user-defined type function environment through a `builtins` submodule of the `types` library.
 
 ## Motivation
 
-Currently, built-in type functions are not immediately accessible within the user-defined type function environment. This is not desired, as the built-in type functions provide utility such as `keyof` and `index`; and ways to handle operations between types with the likes of `add` and `unm`.
+Currently, built-in type functions are not immediately accessible within the user-defined type function environment. We would like to be able to use them because the built-in type functions include both utilities like `keyof` and `index`,  and functions to resolve the types of overloadable operators like `add` and `unm`.
 
-Today, the way to circumvent this is to use boilerplate aliases such as `type proxy_keyof<T> = keyof<T>` to be able to use the built-in type functions; which may seem strange for why these aren't readily available.
+Since user-defined type aliases _are_ exposed to type functions, you can workaround the existing limitation by defining a new alias like `type aliasKeyOf<T> = keyof<T>`. However, we find this workaround to be unnecessarily cumbersome since it must be repeated in each module the user might define a type function using that builtin.
 
 ## Design
 
-A new namespace called `builtins` under the `types` library is to be introduced. This namespace will contain all public-facing built-in type functions that are available.
+We propose introducing a new submodule called `builtins` under the `types` library. This submodule will contain all public-facing built-in type functions that are currently available.
 
 An example:
 ```luau
@@ -29,27 +29,26 @@ type negatable_string = setmetatable<{}, {
 type foo = ultra_negate<negatable_string> -- 'foo' resolves to '~string'
 
 -- * this example previously would have needed to use an alias for 'unm' like seen below
--- type proxy_unm<T> = unm<T>
+-- type aliasUnm<T> = unm<T>
 ```
 
 ## Drawbacks
 
-* There is no precedent to add sub-namespaces to existing libraries in the luau standard library, such as `types.builtins` as this RFC proposes.
+* There is no existing precedent of adding submodules to libraries in the Luau standard library. This RFC proposes to do exactly that with `types.builtins`.
 
-* There is certain built-in type functions that might seem strange to see in the `types` library. One example would be the `setmetatable` built-in, since `tabletype:setmetatable` and `types.newtable`s `metatable` argument supersede this built-in. Users might get confused or distracted trying to discern if it serves a different purpose behaviourally/semantically.
+* Some built-in type functions might be a source of confusion due to overlap with functionality in the `types` library itself. One example would be `setmetatable` which ultimately shares the same behavior as `tabletype:setmetatable`. It may not be immediately obvious whether or not their behaviors differ at all, or when someone should use one or the other.
 
-* The name `builtins` does not indicate that it is a namespace that contains built-in *type functions* specifically.
+* The name `builtins` does not indicate that it is a submodule containing built-in _type functions_ specifically.
 
 ## Alternatives
 
-* Let users write aliases for the built-in type functions the way it currently can be done.
+* Do nothing. This means any uses of built-in type functions will continue to be through aliases introduced by the use.
 
-* Only expose certain built-in type functions *selectively*, instead of exposing all public-facing ones. This would allow superseded built-in type functions like `setmetatable` to be omitted entirely.
-	* This alternative could also lead to other built-ins like `lt` to be renamed to `lessthan`, thus making `types.*` be a more viable alternative to `types.builtins.*`.
+* Only expose certain built-in type functions _selectively_, instead of exposing all public-facing ones. This would allow potentially confusing or redundant builtin type functions like `setmetatable` to be omitted entirely.
 
-### Namespace Alternatives
+### Naming Alternatives
 
-* Dump all built-in type functions into the global namespace
+* Dump all built-in type functions into the global scope
 	* This would be highly undesirable, since now the global namespace is polluted with both value and type functions. And certain labels would clash with already existing labels like `rawget`.
 
 * `types.*`, '*' being the built-in name
@@ -59,7 +58,16 @@ type foo = ultra_negate<negatable_string> -- 'foo' resolves to '~string'
 	* The name `types.builtins` might not indicate that it contains built-in type functions specifically, this alternative could alleviate this issue. Although some may consider it too-verbose.
 
 * `typefunctions.*`
-	* This would fix the problem that comes with implementing `types.builtins` as there is no precedent in luau for such a thing. But the name `typefunctions` is rather ambigous whether it contains *all* type functions (UDTFs included) or rather just the built-in ones.
+	* This would fix the problem that comes with implementing `types.builtins` as there is no existing precedent for nested submodules. However, the name `typefunctions` is ambiguous as to whether it contains _all_ type functions (UDTFs included), or just the built-in ones.
 
 * `builtintypefunctions.*`
 	* This fixes the ambiguity with `typefunctions` but is too verbose, due to this the readability and ergonomics might be impacted.
+
+<!--
+This was a previous alternative proposed, though has been removed due to it's redundancy (i think), here's why:
+1. the built-in type functions are already accessible with names like `lt`. this naming scheme is already consistent with metamethods.
+2. this inconsistency in the name would also be confusing due to, well, it's inconsistency in the name... leading to questions about whether these two things (e.g. `lt` and `lessthan`) are actually 1:1 or not!
+3. unnecessary burden for language developers to define new names for these functions, not the biggest deal ever, but considering the previous two points, this alternative would most likely seem redundant more than anything.
+
+* Only expose certain built-in type functions selectively _and_ rename certain built-in type functions like `lt` to be more verbose like `lessthan`. The main appeal for this would be that, if the naming alternative `types.*` was to be preffered, short and potentially cryptic names like `lt` could look off next to more verbose names like `intersectionof` as was mentioned in the `types.*` alternative; renaming would thus make `types.*` be prefferable.
+-->

--- a/docs/expose-builtin-typefunctions-to-udtf.md
+++ b/docs/expose-builtin-typefunctions-to-udtf.md
@@ -8,13 +8,13 @@ Exposes the built-in type functions present in luau such as `keyof` to the user-
 
 Currently, built-in type functions are not immediately accessible within the user-defined type function environment. This is not desired, as the built-in type functions provide utility such as `keyof` and `index`; and ways to handle operations between types with the likes of `add` and `unm`.
 
-Today, the way to circumvent this is to use boilerplate aliases such as `type proxy_keyof<T> = keyof<T>` to be able to use the built-in type functions; which, at a users glance, may seem erroneous for why these aren't readily available.
+Today, the way to circumvent this is to use boilerplate aliases such as `type proxy_keyof<T> = keyof<T>` to be able to use the built-in type functions; which may seem strange for why these aren't readily available.
 
 ## Design
 
 A new namespace called `builtins` under the `types` library is to be introduced. This namespace will contain all public-facing built-in type functions that are available.
 
-An example using `types.builtins`:
+An example:
 ```luau
 type function ultra_negate(t: type): type
 	return types.negationof(
@@ -27,15 +27,18 @@ type negatable_string = setmetatable<{}, {
 }>
 
 type foo = ultra_negate<negatable_string> -- 'foo' resolves to '~string'
+
+-- * this example previously would have needed to use an alias for 'unm' like seen below
+-- type proxy_unm<T> = unm<T>
 ```
 
 ## Drawbacks
 
 * There is no precedent to add sub-namespaces to existing libraries in the luau standard library, such as `types.builtins` as this RFC proposes.
 
-* There is certain built-in type functions that might seem strange to see in the `types` library. One example would be the `setmetatable` built-in, since `tabletype:setmetatable` and `types.newtable`s `metatable` argument may supersede this built-in. Users might get confused or distracted trying to discern if it serves a different purpose behaviourally/semantically.
+* There is certain built-in type functions that might seem strange to see in the `types` library. One example would be the `setmetatable` built-in, since `tabletype:setmetatable` and `types.newtable`s `metatable` argument supersede this built-in. Users might get confused or distracted trying to discern if it serves a different purpose behaviourally/semantically.
 
-* The name `types.builtins` does not indicate that it contains built-in *type functions* specifically.
+* The name `builtins` does not indicate that it is a namespace that contains built-in *type functions* specifically.
 
 ## Alternatives
 
@@ -49,7 +52,7 @@ type foo = ultra_negate<negatable_string> -- 'foo' resolves to '~string'
 	* This would be highly undesirable, since now the global namespace is polluted with both value and type functions. And certain labels would clash with already existing labels like `rawget`.
 
 * `types.*`, '*' being the built-in name
-	* While this might feel right for some; for others, names like `lt` and `unm` might feel off next to verbose (but concise) names like `intersectionof` and `newfunction`.
+	* This seems like the idiomatic alternative; although, names like `lt` and `unm` might feel off next to verbose (but concise) names like `intersectionof` and `newfunction`.
 
 * `types.typefunctions.*`
 	* The name `types.builtins` might not indicate that it contains built-in type functions specifically, this alternative could alleviate this issue. Although some may consider it too-verbose.
@@ -58,4 +61,4 @@ type foo = ultra_negate<negatable_string> -- 'foo' resolves to '~string'
 	* This would fix the problem that comes with implementing `types.builtins` as there is no precedent in luau for such a thing. But the name `typefunctions` is rather ambigous whether it contains *all* type functions (UDTFs included) or rather just the built-in ones.
 
 * `builtintypefunctions.*`
-	* This fixes the ambiguity with `typefunctions` but is too verbose and the readability is questionable at best.
+	* This fixes the ambiguity with `typefunctions` but is too verbose, due to this the readability and ergonomics might be impacted.

--- a/docs/expose-builtin-typefunctions-to-udtf.md
+++ b/docs/expose-builtin-typefunctions-to-udtf.md
@@ -42,18 +42,18 @@ type foo = ultra_negate<negatable_string> -- 'foo' resolves to '~string'
 
 ## Alternatives
 
-* Do nothing. This means any uses of built-in type functions will continue to be through aliases introduced by the use.
+* Do nothing. This means any uses of built-in type functions will continue to be through aliases introduced by the user.
 
 * Only expose certain built-in type functions _selectively_, instead of exposing all public-facing ones. This would allow potentially confusing or redundant builtin type functions like `setmetatable` to be omitted entirely.
 
 ### Naming Alternatives
 
 * Dump all built-in type functions into the global scope
-	* This would be highly undesirable, since now the global namespace is polluted with both value and type functions. And certain labels would clash with already existing labels like `rawget`.
+	* This would be highly undesirable, since now the global namespace is polluted with both value and type functions. Additionally, certain labels would clash with already existing ones like `rawget`.
 
 * `types.*`, '*' being the built-in name
 	* This seems like the idiomatic alternative; although, names like `lt` and `unm` might feel off next to verbose (but concise) names like `intersectionof` and `newfunction`.
-	* Mixing built-in type functions directly into the `types` library might be undesirable, because the `types` library specifically contains type functions with _known_ return types. For example, when `types.newtable` is used, the return type is guaranteed to be an `tabletype`. In contrast, built-in type functions (especially those that resolve overloadable operators) can evaluate to _any_ arbitrary `type`.
+	* Mixing built-in type functions directly into the `types` library might be undesirable, because the `types` library specifically contains type functions with _known_ return types. For example, when `types.newtable` is used, the return type is guaranteed to be a `tabletype`. In contrast, built-in type functions (especially those that resolve overloadable operators) can evaluate to _any_ arbitrary `type`.
 
 * `types.typefunctions.*`
 	* The name `types.builtins` might not indicate that it contains built-in type functions specifically, this alternative could alleviate this issue. Although some may consider it too-verbose.
@@ -66,8 +66,8 @@ type foo = ultra_negate<negatable_string> -- 'foo' resolves to '~string'
 
 <!--
 This was a previous alternative proposed, though has been removed due to it's redundancy (i think), here's why:
-1. the built-in type functions are already accessible with names like `lt`. this naming scheme is already consistent with metamethods.
-2. this inconsistency in the name would also be confusing due to, well, it's inconsistency in the name... leading to questions about whether these two things (e.g. `lt` and `lessthan`) are actually 1:1 or not!
+1. built-in type functions have names like `lt` for a good reason, this naming scheme is already consistent with metamethods.
+2. this inconsistency in names would also be confusing due to, well, it's inconsistency in the name... leading to questions about whether these two things (e.g. `lt` and `lessthan`) are actually 1:1 or not!
 3. unnecessary burden for language developers to define new names for these functions, not the biggest deal ever, but considering the previous two points, this alternative would most likely seem redundant more than anything.
 
 * Only expose certain built-in type functions selectively _and_ rename certain built-in type functions like `lt` to be more verbose like `lessthan`. The main appeal for this would be that, if the naming alternative `types.*` was to be preffered, short and potentially cryptic names like `lt` could look off next to more verbose names like `intersectionof` as was mentioned in the `types.*` alternative; renaming would thus make `types.*` be prefferable.

--- a/docs/expose-builtin-typefunctions-to-udtf.md
+++ b/docs/expose-builtin-typefunctions-to-udtf.md
@@ -53,6 +53,7 @@ type foo = ultra_negate<negatable_string> -- 'foo' resolves to '~string'
 
 * `types.*`, '*' being the built-in name
 	* This seems like the idiomatic alternative; although, names like `lt` and `unm` might feel off next to verbose (but concise) names like `intersectionof` and `newfunction`.
+	* Mixing built-in type functions directly into the `types` library might be undesirable, because the `types` library specifically contains type functions with _known_ return types. For example, when `types.optional` is used, the return type is guaranteed to be an `optionaltype`. In contrast, built-in type functions (especially those that resolve overloadable operators) can evaluate to _any_ arbitrary `type`.
 
 * `types.typefunctions.*`
 	* The name `types.builtins` might not indicate that it contains built-in type functions specifically, this alternative could alleviate this issue. Although some may consider it too-verbose.


### PR DESCRIPTION
[rendered](https://github.com/SeloTheGreat/luau-rfcs/blob/expose-builtin-typefunctions/docs/expose-builtin-typefunctions-to-udtf.md)

exposes built-in type functions to the UDTF environment with `types.builtins`

happy to change things according to feedback!